### PR TITLE
QOL-6078 Update Footer feedback and Tweak reCAPTCHA code to handle v2 and v3,

### DIFF
--- a/src/assets/_project/_blocks/components/forms/recaptcha.js
+++ b/src/assets/_project/_blocks/components/forms/recaptcha.js
@@ -69,42 +69,74 @@ import keys from '../../data/qg-google-keys';
     grecaptcha.execute();
   };
 
+  let loadedRecaptcha = false;
   let onloadRecaptcha = () => {
     grecaptcha.ready(function () {
     // eslint-disable-line
     //v2 Forms
-      $('form[data-recaptcha="true"]')
-        .find('input[type="submit"], button[type="submit"]')
-        .on('click', e => {
-          e.preventDefault();
-          let subBtn = e.target;
-          let form = $(subBtn).parents('form');
-          var greptcha = form.find('input[name="g-recaptcha-response"]');
-          let manualSitekey = form.attr('data-sitekey');
-          let manualAction = form.attr('data-action');
-          if (form.attr('id') === 'qg-page-feedback-form') { //Footer feedback
-            v3Captcha(form, greptcha, footerFeedbackGoogleRecaptchaApiKey, 'feedback');
-          } else if (manualSitekey !== undefined && manualAction !== undefined) { //v3 manual form
-            v3Captcha(form, greptcha, manualSitekey, manualAction);
-          } else if (manualAction !== undefined) { //v3 manual with feedback key but differnt action
-            v3Captcha(form, greptcha, footerFeedbackGoogleRecaptchaApiKey, manualAction);
-          } else if (manualSitekey !== undefined && manualAction === undefined) { //v2 manual (no action in v2)
-            v2Captcha(form, subBtn, manualSitekey);
-          } else { //default v2 with default key
-            v2Captcha(form, subBtn, googleRecaptchaApiKey);
-          }
-        });
+      if (!loadedRecaptcha) {
+        $('form[data-recaptcha="true"]')
+          .find('input[type="submit"], button[type="submit"]')
+          .on('click', e => {
+            e.preventDefault();
+            let subBtn = e.target;
+            let form = $(subBtn).parents('form');
+            var greptcha = form.find('input[name="g-recaptcha-response"]');
+            let manualSitekey = form.attr('data-sitekey');
+            let manualAction = form.attr('data-action');
+            if (form.attr('id') === 'qg-page-feedback-form') { //Footer feedback
+              v3Captcha(form, greptcha, footerFeedbackGoogleRecaptchaApiKey, 'feedback');
+            } else if (manualSitekey !== undefined && manualAction !== undefined) { //v3 manual form
+              v3Captcha(form, greptcha, manualSitekey, manualAction);
+            } else if (manualAction !== undefined) { //v3 manual with feedback key but differnt action
+              v3Captcha(form, greptcha, footerFeedbackGoogleRecaptchaApiKey, manualAction);
+            } else if (manualSitekey !== undefined && manualAction === undefined) { //v2 manual (no action in v2)
+              v2Captcha(form, subBtn, manualSitekey);
+            } else { //default v2 with default key
+              v2Captcha(form, subBtn, googleRecaptchaApiKey);
+            }
+          });
+        loadedRecaptcha = true;
+      }
     });
   };
+  //https://github.com/google/recaptcha/issues/279
+  //https://github.com/google/recaptcha/issues/281
+  //https://www.hackviking.com/development/multiple-recaptcha-on-the-same-page/
   //Setup recaptcha if on the page
   if ($('form[data-recaptcha="true"]').length > 0) {
     //enable recaptcha on form submits, load latest v3 version of recaptcha
-    swe.ajaxCall(
-      'https://www.google.com/recaptcha/api.js?render=' + footerFeedbackGoogleRecaptchaApiKey,
-      'script',
-      onloadRecaptcha,
-      'Recaptcha unavailable'
-    );
+    let v2Loaded = false;
+    $('form[data-recaptcha="true"]').each(function () {
+      let manualSitekey = $(this).attr('data-sitekey');
+      let manualAction = $(this).attr('data-action');
+      if ($(this).attr('id') === 'qg-page-feedback-form') { //Footer feedback
+        swe.ajaxCall(
+          'https://www.google.com/recaptcha/api.js?render=' + footerFeedbackGoogleRecaptchaApiKey,
+          'script',
+           onloadRecaptcha,
+          'Recaptcha unavailable'
+        );
+      } else if (manualSitekey !== undefined && manualAction !== undefined) { //v3 manual form
+        swe.ajaxCall(
+          'https://www.google.com/recaptcha/api.js?render=' + manualSitekey,
+          'script',
+           onloadRecaptcha,
+          'Recaptcha unavailable'
+        );
+      } else {
+        if (!v2Loaded) {
+          swe.ajaxCall(
+            'https://www.google.com/recaptcha/api.js',
+            'script',
+            onloadRecaptcha,
+            'Recaptcha unavailable'
+          );
+          v2Loaded = true;
+        }
+      }
+    });
+
     //If all forms have captchaPrivacyTerms, we can hide reCAPTCHA Badge
     if ($('p[class="captchaPrivacyTerms"]').length === $('form[data-recaptcha="true"]').length) {
       var hidegrecaptchaBadge = '.grecaptcha-badge { visibility: hidden; }';

--- a/src/assets/_project/_blocks/components/forms/recaptcha.js
+++ b/src/assets/_project/_blocks/components/forms/recaptcha.js
@@ -23,6 +23,7 @@ import keys from '../../data/qg-google-keys';
       : keys.defFeedbackGoogleRecaptcha.prod;//This is a v3 key
   //v3 Captcha, can have multiples
   let v3Captcha = (form, greptcha, key, action) => {
+    //console.log('v3 key: ' + key);
     try {
       grecaptcha.execute(key, {action: action})
       .then(function (token) {
@@ -46,6 +47,7 @@ import keys from '../../data/qg-google-keys';
   //v2 Captcha, usually is singular
   let v2Captcha = (form, subBtn, key) => {
     try {
+      //console.log('v2 key: ' + key);
       grecaptcha.render(subBtn, {
         sitekey: key,
         callback: () => {
@@ -111,12 +113,15 @@ import keys from '../../data/qg-google-keys';
       let manualSitekey = $(this).attr('data-sitekey');
       let manualAction = $(this).attr('data-action');
       if ($(this).attr('id') === 'qg-page-feedback-form') { //Footer feedback
-        swe.ajaxCall(
-          'https://www.google.com/recaptcha/api.js?render=' + footerFeedbackGoogleRecaptchaApiKey,
-          'script',
-           onloadRecaptcha,
-          'Recaptcha unavailable'
-        );
+        //Only load if the feedback button is clicked
+        $('#page-feedback-useful').one('click', function () {
+          swe.ajaxCall(
+            'https://www.google.com/recaptcha/api.js?render=' + footerFeedbackGoogleRecaptchaApiKey,
+            'script',
+            onloadRecaptcha,
+            'Recaptcha unavailable'
+          );
+        });
       } else if (manualSitekey !== undefined && manualAction !== undefined) { //v3 manual form
         swe.ajaxCall(
           'https://www.google.com/recaptcha/api.js?render=' + manualSitekey,

--- a/src/assets/_project/_blocks/data/qg-google-keys.json
+++ b/src/assets/_project/_blocks/data/qg-google-keys.json
@@ -8,6 +8,10 @@
     "uat" : "6LeNGSwUAAAAAD6o-P5UTM0FNpKjYB71Kh70F-Ud",
     "prod" : "6LcoIywUAAAAAN-1rq22G-bP3yxl1bBq_5nHJ6s9"
   },
+  "defFeedbackGoogleRecaptcha" : {
+    "uat" : "6Lf3uLEUAAAAAKbnWYc0iXtctL8TeFC26l43Qyt2",
+    "prod" : "6LcTNMIUAAAAAHiGXUnaO1xlELzXgpWujzEJbFjS"
+  },
   "franchises": [{
     "name": "about",
     "apiKey": "AIzaSyBi-T3vrvcYwouFPqPI5IgLoQxl2hz6Ogs"

--- a/src/assets/_project/_blocks/layout/content/_options.scss
+++ b/src/assets/_project/_blocks/layout/content/_options.scss
@@ -140,7 +140,7 @@
   color: #000;
   @include rem(font-size, 16px);
 
-  #feedback-captcha-container {
+  #feedback-captcha-container, feedback-captcha-container2 {
     display:none;
   }
 

--- a/src/assets/_project/_blocks/layout/content/options.html
+++ b/src/assets/_project/_blocks/layout/content/options.html
@@ -60,24 +60,24 @@
                                 <abbr title="(required)" class="required">*</abbr>
                             </legend>
                             <div class="radio">
-                              <label for="fs-very-dissatisfied">Very <br /> dissatisfied<br /> (1)</label>
                               <input type="radio" name="feedback-satisfaction" value="Very dissatisfied" required="" id="fs-very-dissatisfied" />
+                              <label for="fs-very-dissatisfied">Very dissatisfied (1)</label>
                             </div>
                             <div class="radio">
-                              <label for="fs-dissatisfied">Dissatisfied<br /> (2)</label>
                               <input type="radio" name="feedback-satisfaction" value="Dissatisfied" required="" id="fs-dissatisfied" />
+                              <label for="fs-dissatisfied">Dissatisfied (2)</label>
                             </div>
                             <div class="radio">
-                              <label for="fs-neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied<br /> (3)</label>
                               <input type="radio" name="feedback-satisfaction" value="Neither satisfied or dissatisfied" required="" id="fs-neither-satisfied-or-dissatisfied" />
+                              <label for="fs-neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied (3)</label>
                             </div>
                             <div class="radio">
-                              <label for="fs-satisfied">Satisfied<br /> (4)</label>
                               <input type="radio" name="feedback-satisfaction" value="Satisfied" required="" id="fs-satisfied" />
+                              <label for="fs-satisfied">Satisfied (4)</label>
                             </div>
                             <div class="radio">
-                              <label for="fs-very-satisfied">Very <br /> satisfied<br /> (5)</label>
                               <input type="radio" name="feedback-satisfaction" value="Very satisfied" required="" id="fs-very-satisfied" />
+                              <label for="fs-very-satisfied">Very satisfied (5)</label>
                             </div>
 
                         </fieldset>

--- a/src/assets/_project/_blocks/layout/content/options.html
+++ b/src/assets/_project/_blocks/layout/content/options.html
@@ -60,24 +60,24 @@
                                 <abbr title="(required)" class="required">*</abbr>
                             </legend>
                             <div class="radio">
+                              <label for="fs-very-dissatisfied">Very <br /> dissatisfied<br /> (1)</label>
                               <input type="radio" name="feedback-satisfaction" value="Very dissatisfied" required="" id="fs-very-dissatisfied" />
-                              <label for="fs-very-dissatisfied">Very dissatisfied (1)</label>
                             </div>
                             <div class="radio">
+                              <label for="fs-dissatisfied">Dissatisfied<br /> (2)</label>
                               <input type="radio" name="feedback-satisfaction" value="Dissatisfied" required="" id="fs-dissatisfied" />
-                              <label for="fs-dissatisfied">Dissatisfied (2)</label>
                             </div>
                             <div class="radio">
+                              <label for="fs-neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied<br /> (3)</label>
                               <input type="radio" name="feedback-satisfaction" value="Neither satisfied or dissatisfied" required="" id="fs-neither-satisfied-or-dissatisfied" />
-                              <label for="fs-neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied (3)</label>
                             </div>
                             <div class="radio">
+                              <label for="fs-satisfied">Satisfied<br /> (4)</label>
                               <input type="radio" name="feedback-satisfaction" value="Satisfied" required="" id="fs-satisfied" />
-                              <label for="fs-satisfied">Satisfied (4)</label>
                             </div>
                             <div class="radio">
+                              <label for="fs-very-satisfied">Very <br /> satisfied<br /> (5)</label>
                               <input type="radio" name="feedback-satisfaction" value="Very satisfied" required="" id="fs-very-satisfied" />
-                              <label for="fs-very-satisfied">Very satisfied (5)</label>
                             </div>
 
                         </fieldset>
@@ -91,6 +91,13 @@
                           </label>
                           <textarea class="form-control" name="comments" id="comments" rows="10" cols="40" required="required"></textarea>
                       </div>
+                    </li>
+
+                    <li id="feedback-captcha-container2" class="col-md-12">
+                        <div class="form-group">
+                            <label for="feedback-captchaCatch">Please leave this blank (this helps us identify automatic spam)</label>
+                            <input class="form-control" type="text" name="captchaCatch" id="feedback-captchaCatch" value="" />
+                        </div>
                     </li>
 
                     <li id="feedback-captcha-container" class="col-md-12">
@@ -110,7 +117,11 @@
                             </li>
 
                         </ul>
-
+                        <p class="captchaPrivacyTerms">
+                                This site is protected by reCAPTCHA and the Google
+                                <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+                                <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+                        </p>
                     </li>
 
                 </ol>

--- a/src/assets/_project/_blocks/layout/footer/feedback-form.js
+++ b/src/assets/_project/_blocks/layout/footer/feedback-form.js
@@ -47,6 +47,7 @@ function init (franchiseTitle) {
   addHiddenInput('rspUsrAgent', navigator.userAgent);
   addHiddenInput('browserName', browserName);
   addHiddenInput('OS', navigator.platform);
+  addHiddenInput('g-recaptcha-response', '');
 }
 
 module.exports = { init: init };

--- a/src/docs/captcha-footer-old.html
+++ b/src/docs/captcha-footer-old.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+
+  <title>Forms | Web Template | Queensland Government</title>
+
+  <meta name="description" content="DESCRIPTION">
+  <meta name="keywords" content="KEYWORDS">
+
+  <link rel="schema.DCTERMS" href="http://purl.org/dc/terms/">
+  <link rel="schema.AGLSTERMS" href="http://www.agls.gov.au/agls/terms/">
+
+  <meta name="DCTERMS.creator" scheme="AGLSTERMS.GOLD" content="c=AU; o=The State of Queensland; ou=DEPARTMENT NAME; ou=UNIT NAME">
+  <meta name="DCTERMS.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=The State of Queensland; jurisdiction=Queensland">
+  <meta name="DCTERMS.created" content="2010-11-04">
+  <meta name="DCTERMS.modified" content="2011-03-05">
+  <meta name="DCTERMS.title" content="Components">
+  <meta name="DCTERMS.alternative" content="Who is a carer?">
+  <meta name="DCTERMS.description" content="DESCRIPTION">
+  <meta name="DCTERMS.subject" scheme="AGLSTERMS.APAIS" content="SUBJECT">
+  <meta name="AGLSTERMS.function" scheme="AGLSTERMS.AGIFT" content="FUNCTION">
+  <meta name="DCTERMS.type" scheme="DCTERMS.DCMIType" content="Text">
+  <meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="guidelines">
+  <meta name="DCTERMS.audience" scheme="AGLSTERMS.agls-audience" content="">
+  <meta name="DCTERMS.jurisdiction" scheme="AGLSTERMS.AglsJuri" content="Queensland">
+  <meta name="DCTERMS.license" scheme="DCTERMS.URI" content="http://creativecommons.org/licenses/by/3.0/au/">
+
+  <!--#include virtual="/assets/includes-local/head-assets.html"-->
+
+  <link href="/assets/_project/latest/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
+  <link href="./assets/css/prism.css" media="all" rel="stylesheet" type="text/css">
+
+</head>
+
+<body data-qg-accessibility="true"
+      data-spy="scroll" data-target="#page-nav">
+
+<!--#include virtual="/assets/includes-local/analytics.html"-->
+<!--#include virtual="/assets/includes-local/header/access.html"-->
+
+<div class="container-fluid qg-site-width">
+
+  <header id="qg-site-header">
+    <!--#include virtual="/assets/includes-local/header/coat-of-arms.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/site-utilities.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/site-search.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/global-alert.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/site-nav.html"-->
+  </header>
+
+  <div id="qg-content">
+    <div id="qg-three-col" class="row">
+
+      <!-- START Breadcrumbs -->
+      <nav id="qg-breadcrumb" role="navigation" aria-label="breadcrumb navigation" aria-labelledby="breadcrumb-heading" class="collapse">
+
+        <h2 id="breadcrumb-heading" class="qg-visually-hidden">You are here:</h2>
+
+        <ol class="list-inline">
+          <!--#include virtual="/assets/includes-local/breadcrumbs/breadcrumb-docs.html"-->
+          <li>Forms</li>
+        </ol>
+
+      </nav>
+      <!-- / END Breadcrumbs -->
+
+      <div id="qg-primary-content" role="main">
+
+        <!-- # include virtual="/assets/includes-local/content/alert.html"-->
+
+        <!-- Start page content -->
+
+        sdfsd
+
+        <!-- ################################## -->
+        <div class="qg-content-footer">
+
+          <dl>
+            <dt>Last updated:</dt>
+            <dd>15 October 2019</dd>
+            <dt>Last reviewed:</dt>
+            <dd>15 October 2019</dd>
+          </dl>
+
+        </div>
+        <!-- ################################## -->
+
+        <!-- ################################## -->
+
+      </div>
+
+      <aside id="qg-secondary-content">
+
+        <div id="page-nav"
+             data-parent-width="true"
+             class="qg-aside qg-docs-sidenav"
+             role="complementary"
+             data-spy="affix" data-offset-top="500" data-offset-bottom="900">
+
+          <h2>On this page</h2>
+
+          <ul class="list" role="tablist">
+            <li><a href="#structure-of-a-form">Structure of a form</a></li>
+            <li><a href="#questions">Questions</a></li>
+            <li><a href="#progressive-disclosure">Progressive disclosure</a></li>
+            <li><a href="#autocomplete-address-form">Autocomplete address form</a></li>
+            <li><a href="#client-side-validation">Client-side validation</a></li>
+            <li><a href="#references">References</a></li>
+          </ul>
+          <p>
+            <a href="#top">Back to top</a>
+          </p>
+        </div>
+
+      </aside>
+
+      <!--#include virtual="/assets/includes-local/section-nav/docs-nav.html"-->
+
+    </div>
+    <div id="qg-options" class="row">
+      <div id="qg-share" class="qg-share"></div>
+
+      <div id="qg-feedback-btn">
+        <button class="btn btn-default qg-toggle-btn collapsed qg-icon" id="page-feedback-useful"
+                data-toggle="collapse"
+                data-target="#qg-page-feedback">Feedback</button>
+      </div>
+    </div>
+
+    <div id="qg-page-feedback" class="row collapse">
+
+      <form id="qg-page-feedback-form"
+            method="post"
+            action="https://www.smartservice.qld.gov.au/services/submissions/email/feedback/feedback"
+            class="form"
+            data-recaptcha="true"><!-- data-toggle="true" -->
+
+        <ol class="questions">
+          <li>
+            <fieldset id="page-feedback-about">
+              <legend><span class="label">Is your feedback about:</span></legend>
+              <div class="radio">
+                <input name="page-feedback-about" id="page-feedback-about-this-website" type="radio" value="this website"
+                       data-qg-pr="default"
+                       data-parent="#qg-page-feedback-form"
+                       data-target="#feedback-page">
+                <label for="page-feedback-about-this-website">this website</label>
+              </div>
+              <div class="radio">
+                <input name="page-feedback-about" id="page-feedback-about-a-government-service" type="radio" value="a government service"
+                       data-qg-pr="default"
+                       data-parent="#qg-page-feedback-form"
+                       data-target="#feedback-serv-dep-staff">
+                <label for="page-feedback-about-a-government-service">a government service, department or staff member?</label>
+              </div>
+            </fieldset>
+          </li>
+        </ol>
+
+        <div class="panel">
+
+          <div id="feedback-serv-dep-staff" class="status info panel-collapse collapse">
+            <h2>Feedback on government services, departments and staff</h2>
+            <p>Please use our <a href="https://www.qld.gov.au/contact-us/complaints/">complaints and compliments form</a>.</p>
+          </div>
+
+          <div id="feedback-page" class="panel-collapse collapse">
+
+            <h2>Page feedback</h2>
+
+            <ol id="feedback-page-list" class="questions">
+
+              <li class="col-12">
+
+                <fieldset>
+
+                  <legend>
+                    <span class="label">How satisfied are you with your experience today?</span>
+                    <abbr title="(required)" class="required">*</abbr>
+                  </legend>
+                  <div class="radio">
+                    <input type="radio" name="feedback-satisfaction" value="Very dissatisfied" required="" id="fs-very-dissatisfied" />
+                    <label for="fs-very-dissatisfied">Very dissatisfied (1)</label>
+                  </div>
+                  <div class="radio">
+                    <input type="radio" name="feedback-satisfaction" value="Dissatisfied" required="" id="fs-dissatisfied" />
+                    <label for="fs-dissatisfied">Dissatisfied (2)</label>
+                  </div>
+                  <div class="radio">
+                    <input type="radio" name="feedback-satisfaction" value="Neither satisfied or dissatisfied" required="" id="fs-neither-satisfied-or-dissatisfied" />
+                    <label for="fs-neither-satisfied-or-dissatisfied">Neither satisfied or dissatisfied (3)</label>
+                  </div>
+                  <div class="radio">
+                    <input type="radio" name="feedback-satisfaction" value="Satisfied" required="" id="fs-satisfied" />
+                    <label for="fs-satisfied">Satisfied (4)</label>
+                  </div>
+                  <div class="radio">
+                    <input type="radio" name="feedback-satisfaction" value="Very satisfied" required="" id="fs-very-satisfied" />
+                    <label for="fs-very-satisfied">Very satisfied (5)</label>
+                  </div>
+
+                </fieldset>
+              </li>
+
+              <li class="col-12">
+                <div class="form-group">
+                  <label for="comments">
+                    <span class="label">Comments</span>
+                    <abbr title="(required)" class="required">*</abbr>
+                  </label>
+                  <textarea class="form-control" name="comments" id="comments" rows="10" cols="40" required="required"></textarea>
+                </div>
+              </li>
+
+              <li id="feedback-captcha-container2" class="col-md-12">
+                <div class="form-group">
+                  <label for="feedback-captchaCatch">Please leave this blank (this helps us identify automatic spam)</label>
+                  <input class="form-control" type="text" name="captchaCatch" id="feedback-captchaCatch" value="" />
+                </div>
+              </li>
+
+              <li id="feedback-captcha-container" class="col-md-12">
+                <div class="form-group">
+                  <label for="feedback-captcha">Please leave this blank (this helps us identify automatic spam)</label>
+                  <input class="form-control" type="text" name="captcha" id="feedback-captcha" value="" />
+                </div>
+              </li>
+
+              <li class="footer col-md-12">
+                <span id="feedback-hidden-inputs"></span>
+
+                <ul class="actions">
+
+                  <li>
+                    <button type="submit" value="Submit feedback" class="qg-btn btn-primary">Submit feedback</button>
+                  </li>
+
+                </ul>
+
+              </li>
+
+            </ol>
+
+          </div>
+
+        </div>
+
+      </form>
+
+    </div>
+
+  </div>
+
+  <footer>
+    <!--#include virtual="/assets/includes-local/footer/footer-site-map.html"-->
+    <!--#include virtual="/assets/includes-local/footer/footer-legals.html"-->
+  </footer>
+</div>
+
+<script>
+  var qg = qg || {};
+  qg.swe = qg.swe || {};
+  // Used by the feedback form.
+  qg.swe.franchiseTitle = 'Franchise Title';
+</script>
+
+<!--#include virtual="/assets/includes-local/footer/footer-scripts.html"-->
+<script type="text/javascript" src="./assets/js/prism.js"></script>
+
+</body>
+
+</html>

--- a/src/docs/captcha-footer-only.html
+++ b/src/docs/captcha-footer-only.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+
+  <title>Forms | Web Template | Queensland Government</title>
+
+  <meta name="description" content="DESCRIPTION">
+  <meta name="keywords" content="KEYWORDS">
+
+  <link rel="schema.DCTERMS" href="http://purl.org/dc/terms/">
+  <link rel="schema.AGLSTERMS" href="http://www.agls.gov.au/agls/terms/">
+
+  <meta name="DCTERMS.creator" scheme="AGLSTERMS.GOLD" content="c=AU; o=The State of Queensland; ou=DEPARTMENT NAME; ou=UNIT NAME">
+  <meta name="DCTERMS.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=The State of Queensland; jurisdiction=Queensland">
+  <meta name="DCTERMS.created" content="2010-11-04">
+  <meta name="DCTERMS.modified" content="2011-03-05">
+  <meta name="DCTERMS.title" content="Components">
+  <meta name="DCTERMS.alternative" content="Who is a carer?">
+  <meta name="DCTERMS.description" content="DESCRIPTION">
+  <meta name="DCTERMS.subject" scheme="AGLSTERMS.APAIS" content="SUBJECT">
+  <meta name="AGLSTERMS.function" scheme="AGLSTERMS.AGIFT" content="FUNCTION">
+  <meta name="DCTERMS.type" scheme="DCTERMS.DCMIType" content="Text">
+  <meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="guidelines">
+  <meta name="DCTERMS.audience" scheme="AGLSTERMS.agls-audience" content="">
+  <meta name="DCTERMS.jurisdiction" scheme="AGLSTERMS.AglsJuri" content="Queensland">
+  <meta name="DCTERMS.license" scheme="DCTERMS.URI" content="http://creativecommons.org/licenses/by/3.0/au/">
+
+  <!--#include virtual="/assets/includes-local/head-assets.html"-->
+
+  <link href="/assets/_project/latest/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
+  <link href="./assets/css/prism.css" media="all" rel="stylesheet" type="text/css">
+
+</head>
+
+<body data-qg-accessibility="true"
+      data-spy="scroll" data-target="#page-nav">
+
+<!--#include virtual="/assets/includes-local/analytics.html"-->
+<!--#include virtual="/assets/includes-local/header/access.html"-->
+
+<div class="container-fluid qg-site-width">
+
+  <header id="qg-site-header">
+    <!--#include virtual="/assets/includes-local/header/coat-of-arms.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/site-utilities.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/site-search.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/global-alert.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/site-nav.html"-->
+  </header>
+
+  <div id="qg-content">
+    <div id="qg-three-col" class="row">
+
+      <!-- START Breadcrumbs -->
+      <nav id="qg-breadcrumb" role="navigation" aria-label="breadcrumb navigation" aria-labelledby="breadcrumb-heading" class="collapse">
+
+        <h2 id="breadcrumb-heading" class="qg-visually-hidden">You are here:</h2>
+
+        <ol class="list-inline">
+          <!--#include virtual="/assets/includes-local/breadcrumbs/breadcrumb-docs.html"-->
+          <li>Forms</li>
+        </ol>
+
+      </nav>
+      <!-- / END Breadcrumbs -->
+
+      <div id="qg-primary-content" role="main">
+
+        <!-- # include virtual="/assets/includes-local/content/alert.html"-->
+
+        <!-- Start page content -->
+
+        sdfsd
+
+        <!-- ################################## -->
+        <div class="qg-content-footer">
+
+          <dl>
+            <dt>Last updated:</dt>
+            <dd>15 October 2019</dd>
+            <dt>Last reviewed:</dt>
+            <dd>15 October 2019</dd>
+          </dl>
+
+        </div>
+        <!-- ################################## -->
+
+        <!-- ################################## -->
+
+      </div>
+
+      <aside id="qg-secondary-content">
+
+        <div id="page-nav"
+             data-parent-width="true"
+             class="qg-aside qg-docs-sidenav"
+             role="complementary"
+             data-spy="affix" data-offset-top="500" data-offset-bottom="900">
+
+          <h2>On this page</h2>
+
+          <ul class="list" role="tablist">
+            <li><a href="#structure-of-a-form">Structure of a form</a></li>
+            <li><a href="#questions">Questions</a></li>
+            <li><a href="#progressive-disclosure">Progressive disclosure</a></li>
+            <li><a href="#autocomplete-address-form">Autocomplete address form</a></li>
+            <li><a href="#client-side-validation">Client-side validation</a></li>
+            <li><a href="#references">References</a></li>
+          </ul>
+          <p>
+            <a href="#top">Back to top</a>
+          </p>
+        </div>
+
+      </aside>
+
+      <!--#include virtual="/assets/includes-local/section-nav/docs-nav.html"-->
+
+    </div>
+    <!--#include virtual="/assets/includes-local/content/options.html"-->
+  </div>
+
+  <footer>
+    <!--#include virtual="/assets/includes-local/footer/footer-site-map.html"-->
+    <!--#include virtual="/assets/includes-local/footer/footer-legals.html"-->
+  </footer>
+</div>
+
+<script>
+  var qg = qg || {};
+  qg.swe = qg.swe || {};
+  // Used by the feedback form.
+  qg.swe.franchiseTitle = 'Franchise Title';
+</script>
+
+<!--#include virtual="/assets/includes-local/footer/footer-scripts.html"-->
+<script type="text/javascript" src="./assets/js/prism.js"></script>
+
+</body>
+
+</html>

--- a/src/docs/captcha.html
+++ b/src/docs/captcha.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+
+  <title>Forms | Web Template | Queensland Government</title>
+
+  <meta name="description" content="DESCRIPTION">
+  <meta name="keywords" content="KEYWORDS">
+
+  <link rel="schema.DCTERMS" href="http://purl.org/dc/terms/">
+  <link rel="schema.AGLSTERMS" href="http://www.agls.gov.au/agls/terms/">
+
+  <meta name="DCTERMS.creator" scheme="AGLSTERMS.GOLD" content="c=AU; o=The State of Queensland; ou=DEPARTMENT NAME; ou=UNIT NAME">
+  <meta name="DCTERMS.publisher" scheme="AGLSTERMS.AglsAgent" content="corporateName=The State of Queensland; jurisdiction=Queensland">
+  <meta name="DCTERMS.created" content="2010-11-04">
+  <meta name="DCTERMS.modified" content="2011-03-05">
+  <meta name="DCTERMS.title" content="Components">
+  <meta name="DCTERMS.alternative" content="Who is a carer?">
+  <meta name="DCTERMS.description" content="DESCRIPTION">
+  <meta name="DCTERMS.subject" scheme="AGLSTERMS.APAIS" content="SUBJECT">
+  <meta name="AGLSTERMS.function" scheme="AGLSTERMS.AGIFT" content="FUNCTION">
+  <meta name="DCTERMS.type" scheme="DCTERMS.DCMIType" content="Text">
+  <meta name="AGLSTERMS.documentType" scheme="AGLSTERMS.agls-document" content="guidelines">
+  <meta name="DCTERMS.audience" scheme="AGLSTERMS.agls-audience" content="">
+  <meta name="DCTERMS.jurisdiction" scheme="AGLSTERMS.AglsJuri" content="Queensland">
+  <meta name="DCTERMS.license" scheme="DCTERMS.URI" content="http://creativecommons.org/licenses/by/3.0/au/">
+
+  <!--#include virtual="/assets/includes-local/head-assets.html"-->
+
+  <link href="/assets/_project/latest/css/qg-documentation.css" rel="stylesheet" type="text/css" media="all">
+  <link href="./assets/css/prism.css" media="all" rel="stylesheet" type="text/css">
+
+</head>
+
+<body data-qg-accessibility="true"
+      data-spy="scroll" data-target="#page-nav">
+
+<!--#include virtual="/assets/includes-local/analytics.html"-->
+<!--#include virtual="/assets/includes-local/header/access.html"-->
+
+<div class="container-fluid qg-site-width">
+
+  <header id="qg-site-header">
+    <!--#include virtual="/assets/includes-local/header/coat-of-arms.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/site-utilities.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/site-search.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/global-alert.html"-->
+
+    <!--#include virtual="/assets/includes-local/header/site-nav.html"-->
+  </header>
+
+  <div id="qg-content">
+    <div id="qg-three-col" class="row">
+
+      <!-- START Breadcrumbs -->
+      <nav id="qg-breadcrumb" role="navigation" aria-label="breadcrumb navigation" aria-labelledby="breadcrumb-heading" class="collapse">
+
+        <h2 id="breadcrumb-heading" class="qg-visually-hidden">You are here:</h2>
+
+        <ol class="list-inline">
+          <!--#include virtual="/assets/includes-local/breadcrumbs/breadcrumb-docs.html"-->
+          <li>Forms</li>
+        </ol>
+
+      </nav>
+      <!-- / END Breadcrumbs -->
+
+      <div id="qg-primary-content" role="main">
+
+        <!-- # include virtual="/assets/includes-local/content/alert.html"-->
+
+        <!-- Start page content -->
+
+        <h1>ReCaptcha Loadings</h1>
+        <a href="captcha-footer-old.html">Footer old</a><br/>
+        <a href="captcha-footer-only.html">Footer only</a><br/>
+
+        <div id="test1">
+          <h1>Test 1 v3 replace action only data-action="homepage"</h1>
+          <form method="post" id="qg-page-feedback-form-1"
+                action="https://test.smartservice.qld.gov.au/services/submissions/email/feedback/feedback"
+                class="form"
+                data-recaptcha="true"
+                data-action="homepage">
+            <input class="form-control" type="hidden" name="g-recaptcha-response" value="" />
+            <h2>Page feedback A</h2>
+            <ol class="questions">
+              <li class="col-12">
+                <div class="form-group">
+                  <label for="comments-a">
+                    <span class="label">Comments</span>
+                    <abbr title="(required)" class="required">*</abbr>
+                  </label>
+                  <textarea class="form-control" name="comments" id="comments-a" rows="1" cols="40" required="required">Test 1 v3 replace action only data-action="homepage"</textarea>
+                </div>
+              </li>
+              <li class="col-md-12">
+              <li class="footer col-md-12">
+                <span id="feedback-hidden-inputs"></span>
+
+                <ul class="actions">
+                  <li>
+                    <button type="submit" value="Submit feedback" class="qg-btn btn-primary">Submit feedback</button>
+                  </li>
+                </ul>
+                <p class="captchaPrivacyTerms">
+                  This site is protected by reCAPTCHA and the Google
+                  <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+                  <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+                </p>
+              </li>
+            </ol>
+          </form>
+        </div>
+
+        <div id="test2"><h1>Test 2 v3 replaced site and action</h1>
+          <form method="post" id="qg-page-feedback-form-2"
+                action="https://test.smartservice.qld.gov.au/services/submissions/email/qld/chg-5597-recaptcha"
+                class="form"
+                data-recaptcha="true"
+                data-sitekey="6Ld3DLQUAAAAAAwEpt_EFc9whPKCUWRlo4GKz5aJ"
+                data-action="homepage2">
+            <input class="form-control" type="hidden" name="g-recaptcha-response" value="" />
+            <h2>Page feedback B</h2>
+            <ol class="questions">
+              <li class="col-12"><div class="form-group">
+                <label for="comments-b">
+                  <span class="label">Comments</span>
+                  <abbr title="(required)" class="required">*</abbr>
+                </label>
+                <textarea class="form-control" name="comments" id="comments-b" rows="1" cols="40" required="required">Test 2 v3 replaced site and action</textarea>
+              </div></li>
+              <li class="col-md-12">
+              <li class="footer col-md-12">
+                <ul class="actions"><li>
+                  <button type="submit" value="Submit feedback" class="qg-btn btn-primary">Submit feedback</button>
+                </li></ul>
+                <p class="captchaPrivacyTerms">
+                  This site is protected by reCAPTCHA and the Google
+                  <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+                  <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+                </p>
+              </li>
+            </ol>
+          </form></div>
+
+        <div id="test3"><h1>Test 3 v2 custom</h1>
+          <form method="post" id="qg-page-feedback-form-3"
+                action="https://test.smartservice.qld.gov.au/services/submissions/email/qld/chg-5597-recaptcha-v2"
+                class="form"
+                data-recaptcha="true"
+                data-sitekey="6LcJ1MIUAAAAAOzzbeRnkuNjBIeEio5Nxc2N6rVM" >
+            <h2>Page feedback B</h2>
+            <ol class="questions">
+              <li class="col-12"><div class="form-group">
+                <label for="comments-c">
+                  <span class="label">Comments</span>
+                  <abbr title="(required)" class="required">*</abbr>
+                </label>
+                <textarea class="form-control" name="comments" id="comments-c" rows="1" cols="40" required="required">Test 3 v2 custom</textarea>
+              </div></li>
+              <li class="col-md-12">
+              <li class="footer col-md-12">
+                <ul class="actions"><li>
+                  <button type="submit" value="Submit feedback" class="qg-btn btn-primary">Submit feedback</button>
+                </li></ul>
+                <p class="captchaPrivacyTerms">
+                  This site is protected by reCAPTCHA and the Google
+                  <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+                  <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+                </p>
+              </li>
+            </ol>
+          </form></div>
+
+        <div id="test4"><h1>Test 4 v2 default</h1>
+          <form method="post" id="qg-page-feedback-form-4"
+                action="https://test.smartservice.qld.gov.au/services/submissions/email/qld/chg-5597-recaptcha-v2-default"
+                class="form"
+                data-recaptcha="true">
+            <h2>Page feedback B</h2>
+            <ol class="questions">
+              <li class="col-12"><div class="form-group">
+                <label for="comments-d">
+                  <span class="label">Comments</span>
+                  <abbr title="(required)" class="required">*</abbr>
+                </label>
+                <textarea class="form-control" name="comments" id="comments-d" rows="1" cols="40" required="required">Test 4 v2 default</textarea>
+              </div></li>
+              <li  class="col-md-12">
+              <li class="footer col-md-12">
+                <ul class="actions"><li>
+                  <button type="submit" value="Submit feedback" class="qg-btn btn-primary">Submit feedback</button>
+                </li></ul>
+                <p class="captchaPrivacyTerms">
+                  This site is protected by reCAPTCHA and the Google
+                  <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+                  <a href="https://policies.google.com/terms">Terms of Service</a> apply.
+                </p>
+              </li>
+            </ol>
+          </form></div>
+
+        <!-- ################################## -->
+        <div class="qg-content-footer">
+
+          <dl>
+            <dt>Last updated:</dt>
+            <dd>15 October 2019</dd>
+            <dt>Last reviewed:</dt>
+            <dd>15 October 2019</dd>
+          </dl>
+
+        </div>
+        <!-- ################################## -->
+
+        <!-- ################################## -->
+
+      </div>
+
+      <aside id="qg-secondary-content">
+
+        <div id="page-nav"
+             data-parent-width="true"
+             class="qg-aside qg-docs-sidenav"
+             role="complementary"
+             data-spy="affix" data-offset-top="500" data-offset-bottom="900">
+
+          <h2>On this page</h2>
+
+          <ul class="list" role="tablist">
+            <li><a href="#structure-of-a-form">Structure of a form</a></li>
+          <li><a href="#questions">Questions</a></li>
+          <li><a href="#progressive-disclosure">Progressive disclosure</a></li>
+          <li><a href="#autocomplete-address-form">Autocomplete address form</a></li>
+          <li><a href="#client-side-validation">Client-side validation</a></li>
+          <li><a href="#references">References</a></li>
+          </ul>
+          <p>
+            <a href="#top">Back to top</a>
+          </p>
+        </div>
+
+      </aside>
+
+      <!--#include virtual="/assets/includes-local/section-nav/docs-nav.html"-->
+
+    </div>
+    <!--#include virtual="/assets/includes-local/content/options.html"-->
+  </div>
+
+  <footer>
+    <!--#include virtual="/assets/includes-local/footer/footer-site-map.html"-->
+    <!--#include virtual="/assets/includes-local/footer/footer-legals.html"-->
+  </footer>
+</div>
+
+<script>
+  var qg = qg || {};
+  qg.swe = qg.swe || {};
+  // Used by the feedback form.
+  qg.swe.franchiseTitle = 'Franchise Title';
+</script>
+
+<!--#include virtual="/assets/includes-local/footer/footer-scripts.html"-->
+<script type="text/javascript" src="./assets/js/prism.js"></script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Add missing footer feedback field which is required. 
Tweak recaptcha code to handle v2 and v3, add new v3 keys for footer feedback but still allow v2 when its not footer feed back on the page unless override options data-sitekey and or data-recaptcha-action is set on the form

based on https://github.com/qld-gov-au/squiz_theme/blob/ed8492032f677789e80cb3718f525656215e8076/assets/includes/global-remote/page-options-post.html for footer feedback

Also improvements which @andersmx  was working on in another project