### PR TITLE
Qol 8453 add tests on alert and call out box

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,4 +38,15 @@
     ],
     "no-warning-comments": 1,
   },
+  "overrides": [
+    {
+      "files": [
+        "e2e/__tests__/**/*-test.js",
+        "jest.setup.js"
+      ],
+      "env": {
+        "jest": true
+      }
+    }
+  ]
 }

--- a/e2e/__tests__/components/alert-test.js
+++ b/e2e/__tests__/components/alert-test.js
@@ -1,0 +1,26 @@
+const puppeteer = require('puppeteer');
+const ct = require('../../config/constants');
+let browser;
+let page;
+
+beforeAll(async () => {
+  browser = await puppeteer.launch({headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox']});
+  page = await browser.newPage();
+  await page.setViewport({ width: ct.BT_XL, height: ct.WH });
+});
+
+describe('SWE Components testing', () => {
+  test('Warning appears if alert contains `i` element as font awesome icon', async () => {
+    let consoleMsg = '';
+    page.on('console', consoleObj => { consoleMsg = consoleObj.text(); });
+    await page.goto(`${ct.APP_URL}/docs/components/alerts.html`, { waitUntil: 'networkidle0' });
+    // 1. -> alert contains deprecate icon
+    await page.waitForSelector('.alert h2 i.fa');
+    // 2. -> warning appears in console
+    expect(consoleMsg).toEqual('Please change the font awesome element in Alert from i to span, we\'ll be removing the css in this element before 22nd june 2022. Please refer to the https://github.com/qld-gov-au/qg-web-template/pull/391 for more details.');
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+});

--- a/e2e/__tests__/components/call-out-box-test.js
+++ b/e2e/__tests__/components/call-out-box-test.js
@@ -1,0 +1,26 @@
+const puppeteer = require('puppeteer');
+const ct = require('../../config/constants');
+let browser;
+let page;
+
+beforeAll(async () => {
+  browser = await puppeteer.launch({headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox']});
+  page = await browser.newPage();
+  await page.setViewport({ width: ct.BT_XL, height: ct.WH });
+});
+
+describe('SWE Components testing', () => {
+  test('Warning appears if call out box contains `i` element as font awesome icon', async () => {
+    let consoleMsg = '';
+    page.on('console', consoleObj => { consoleMsg = consoleObj.text(); });
+    await page.goto(`${ct.APP_URL}/docs/components/call-out-box.html`, { waitUntil: 'networkidle0' });
+    // 1. -> call out box contains deprecate icon
+    await page.waitForSelector('.qg-callout__box .qg-callout__icon i.fa');
+    // 2. -> warning appears in console
+    expect(consoleMsg).toEqual('Please change the font awesome element in Callout box from i to span, we\'ll be removing the css in this element before 22nd june 2022. Please refer to the https://github.com/qld-gov-au/qg-web-template/pull/391 for more details.');
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+});

--- a/src/assets/_project/_blocks/utils/qg-misc.js
+++ b/src/assets/_project/_blocks/utils/qg-misc.js
@@ -71,8 +71,9 @@
     },
   ];
   deprecationWarnings.forEach(({selector, label}) => {
-    if ($(selector).length > 0) {
-      console.info(`Please change the font awesome element in ${label} from i to span, we'll be removing the css in this element before 22nd june 2022. Please refer to the https://github.com/qld-gov-au/qg-web-template/pull/391 for more details.`);
-    }
+    // use `show` if the element is created on the fly
+    $(selector).show(() => {
+      console.warn(`Please change the font awesome element in ${label} from i to span, we'll be removing the css in this element before 22nd june 2022. Please refer to the https://github.com/qld-gov-au/qg-web-template/pull/391 for more details.`);
+    });
   });
 })(jQuery, qg.swe);

--- a/src/docs/components/alerts.html
+++ b/src/docs/components/alerts.html
@@ -188,8 +188,27 @@
   &lt;h2>Alert title&lt;/h2>
   &lt;p>Alert content&lt;/p>
 &lt;/div>
-                                        </code></pre>
-
+        </code></pre>
+        <h3>Deprecation</h3>
+        <p>
+          We will deprecate the CSS support for &lt;i class="fa ..."&gt; Font Awesome icons due to incompatible to semantic HTML (https://github.com/qld-gov-au/qg-web-template/pull/391).
+          <br/>
+          Please replace &lt;i&gt; with &lt;span&gt; for Font Awesome icons if they are used in your application by 22nd June 2022.
+        </p>
+        <div class="alert alert-danger" role="alert">
+          <h2><i class="fa fa-ban"></i> Alert using &lt;i&gt; as Font Awesome icon</h2>
+          <p>A warning will appear in console to remind developer to replace the Font Awesome icon if &lt;i&gt; is used.</p>
+        </div>
+        <p>Please modify your code from:</p>
+        <pre>
+<code class="language-markup">&lt;div class="alert alert-warning" role="alert">
+  &lt;h2>&lt;i class="fa fa-exclamation-triangle">&lt;/i>Alert title&lt;/h2>
+&lt;/div></code></pre>
+        <p>to:</p>
+        <pre>
+<code class="language-markup">&lt;div class="alert alert-warning" role="alert">
+  &lt;h2>&lt;span class="fa fa-exclamation-triangle">&lt;/span>Alert masssage&lt;/h2>
+&lt;/div></code></pre>
       </div>
     </div>
   </div>

--- a/src/docs/components/call-out-box.html
+++ b/src/docs/components/call-out-box.html
@@ -147,7 +147,7 @@
         &lt;section class=&quot;qg-callout__box&quot;&gt;
           &lt;div class=&quot;qg-callout__header col-12&quot;&gt;
              &lt;span class=&quot;qg-callout__icon&quot;&gt;
-                 &lt;i class=&quot;fa fa-comments&quot;&gt;&lt;/i&gt;
+                 &lt;span class=&quot;fa fa-comments&quot;&gt;&lt;/span&gt;
              &lt;/span&gt;
             &lt;h2 class=&quot;qg-callout__title&quot;&gt;Tell us what you think about our website&lt;/h2&gt;
           &lt;/div&gt;
@@ -168,7 +168,37 @@
         <ul>
           <li>This component supports having some contextual text to accompany a button.</li>
         </ul>
-
+        <h3>Deprecation</h3>
+        <p>
+          We will deprecate the CSS support for &lt;i class="fa ..."&gt; Font Awesome icons due to incompatible to semantic HTML (https://github.com/qld-gov-au/qg-web-template/pull/391).
+          <br/>
+          Please replace &lt;i&gt; with &lt;span&gt; for Font Awesome icons if they are used in your application by 22nd June 2022.
+        </p>
+        <section class="qg-callout__box qg-callout__grey-theme">
+          <div class="qg-callout__header col-12">
+            <span class="qg-callout__icon">
+              <i class="fa fa-comments"></i>
+            </span>
+            <h2 class="qg-callout__title">Call out box using &lt;i&gt; as Font Awesome icon</h2>
+          </div>
+          <div class="qg-callout__content col-12">
+            <div class="qg-callout__bottom-alignment">
+              <div class="qg-callout__description">
+                <p>A warning will appear in console to remind developer to replace the Font Awesome icon if &lt;i&gt; is used.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+        <p>Please modify your code from:</p>
+        <pre>
+        <code class="language-markup">&lt;span class=&quot;qg-callout__icon&quot;&gt;
+          &lt;i class=&quot;fa fa-comments&quot;&gt;&lt;/i&gt;
+        &lt;/span&gt;</code></pre>
+        <p>to:</p>
+        <pre>
+        <code class="language-markup">&lt;span class=&quot;qg-callout__icon&quot;&gt;
+          &lt;span class=&quot;fa fa-comments&quot;&gt;&lt;/span&gt;
+        &lt;/span&gt;</code></pre>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- add tests in `alert` and `call-out-box` component to test the warning message if `i` element is used for FA icon
- add deprecation stories to doc to instruct consumers
- fix a minor eslint issue in vscode