### PR TITLE
Removed max-width to allow long breadcrumbs to fill line space available

### DIFF
--- a/src/assets/_project/_blocks/layout/breadcrumbs/_breadcrumbs.scss
+++ b/src/assets/_project/_blocks/layout/breadcrumbs/_breadcrumbs.scss
@@ -14,10 +14,7 @@
 
 		&-item {
 			display: block;
-      float: left;
-			max-width: 500px;
-			//white-space: nowrap;
-			transition: max-width .3s ease;
+      		float: left;
 
 			&:first-child:before {
 				display: none;


### PR DESCRIPTION
Also removed transition animation as not needed and requires a width to be set to work. See [https://css-tricks.com/using-css-transitions-auto-dimensions/](https://css-tricks.com/using-css-transitions-auto-dimensions/)