### PR TITLE
Qol 9230 add storybook part4

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
+    "storybook-addon-pseudo-states",
   ],
   staticDirs: ["../build"],
   previewMainTemplate: "./.storybook/previewMainTemplate.ejs",

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,14 +1,39 @@
+const path = require("path");
+
 module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
-  "addons": [
+  stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+  addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "@storybook/addon-interactions"
+    "@storybook/addon-interactions",
   ],
-  "staticDirs": ['../build'],
-  "previewMainTemplate": "./.storybook/previewMainTemplate.ejs",
-  "framework": "@storybook/html"
-}
+  staticDirs: ["../build"],
+  previewMainTemplate: "./.storybook/previewMainTemplate.ejs",
+  framework: "@storybook/html",
+  webpackFinal: async (config, { configType }) => {
+    // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'
+    // You can change the configuration based on that.
+    // 'PRODUCTION' is used when building the static version of storybook.
+
+    // Make whatever fine-grained changes you need
+    config.module.rules.push({
+      test: /\.html?$/,
+      use: [
+        {
+          loader: "webpack-ssi-include-loader",
+          options: {
+            localPath: "/",
+            location: "http://localhost:6006", // http url where the file can be dl
+            onFileMatch: (filePath, fileContent, isLocal) => {
+              return fileContent.replaceAll(
+                'virtual=".',
+                `virtual="${filePath.slice(0, filePath.lastIndexOf("/"))}/.`
+              );
+            },
+          },
+        },
+      ],
+    });
+    return config;
+  },
+};

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "run-sequence": "^1.1.5",
     "sass": "^1.38.0",
     "sass-migrator": "^1.5.1",
+    "storybook-addon-pseudo-states": "^1.15.1",
     "string-replace-loader": "^2.3.0",
     "style-loader": "^0.17.0",
     "terser-webpack-plugin": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "url-loader": "^0.5.8",
     "vinyl-fs": "^3.0.3",
     "webpack": "^4.43.0",
+    "webpack-ssi-include-loader": "^1.6.1",
     "webpack-stream": "^5.2.1"
   },
   "dependencies": {

--- a/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
+++ b/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
@@ -26,7 +26,7 @@
           font-weight: bold;
           padding-right: 1.8rem;
         }
-        &:hover {
+        &:hover, &.hover {
           .title{
             text-decoration: none;
             color: $qg-dark-grey-darker;
@@ -69,7 +69,7 @@
       }
     }
   }
-  button:focus{
+  button:focus, button.focus {
     outline: 2px solid #0096d6 !important;
     outline-offset: 2px;
     z-index: 100;
@@ -106,7 +106,7 @@
     display: inline-block;
   }
   .expand, .collapse, label[for="expand"], label[for="collapse"] {
-    &:hover {
+    &:hover, &.hover {
       text-decoration: underline !important;
     }
   }
@@ -233,10 +233,11 @@
 
 // IOS safari specific styles
 @media not all and (min-resolution:.001dpcm) {
-  .qg-accordion .acc-heading:focus {
+  .qg-accordion .acc-heading:focus, .qg-accordion .acc-heading.focus {
     outline: 2px solid $qg-blue;
   }
-  .qg-accordion .expand:focus, .qg-accordion .expand:active, .qg-accordion .collapse:focus, .qg-accordion .collapse:active{
+  .qg-accordion .expand:focus, .qg-accordion .expand:active, .qg-accordion .collapse:focus, .qg-accordion .collapse:active, 
+  .qg-accordion .expand.focus, .qg-accordion .expand.active, .qg-accordion .collapse.focus, .qg-accordion .collapse.active {
     outline: 2px solid $qg-blue !important;
     outline-offset: -2px;
   }

--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -1,3 +1,7 @@
+@mixin hover() {
+  &:hover:not(:disabled, .disabled), &.hover:not(:disabled, .disabled) { @content; }
+}
+
 .btn-global-primary{
   color: #fff;
   background-color: $qg-global-primary-dark-grey;
@@ -9,13 +13,13 @@
     padding: 9px 11px;
   }
 
-  &:hover, &:focus {
+  &:hover, &:focus, &.hover, &.focus {
     text-decoration: underline;
     color: #fff;
     background-color: $qg-global-primary-dark-grey;
   }
 
-  &:focus {
+  &:focus, &.focus {
     outline: 1px dotted #000;
     outline: 5px auto -webkit-focus-ring-color;
   }
@@ -34,12 +38,12 @@
     padding: 9px 11px;
   }
 
-  &:hover, &:focus {
+  &:hover, &:focus, &.hover, &.focus {
     color: $qg-global-primary-dark-grey;
     text-decoration: underline;
   }
 
-  &:focus {
+  &:focus, &.focus {
     outline: 1px dotted #000;
     outline: 5px auto -webkit-focus-ring-color;
   }
@@ -55,12 +59,12 @@
   padding: 7px 24px;
   text-decoration: none;
 
-  &:hover, &:focus {
+  &:hover, &:focus, &.hover, &.focus {
     color: #fff;
     text-decoration: underline;
   }
 
-  &:focus {
+  &:focus, &.focus {
     outline: 1px dotted #000;
     outline: 5px auto -webkit-focus-ring-color;
   }
@@ -69,7 +73,7 @@
 .btn-primary{
   @include button-variant($qg-light-green, $qg-light-green, lighten($qg-light-green, 7.5%), $hover-border: $qg-light-green, $active-background:$qg-light-green, $active-border: $qg-light-green);
   color: #000;
-  a, &:focus, &:hover, &:link, &:visited, &:active {
+  a, &:focus:not(:disabled), &:hover:not(:disabled), &:link:not(:disabled), &:visited:not(:disabled), &:active:not(:disabled), &.focus:not(:disabled), &.hover:not(:disabled), &.link:not(:disabled), &.visited:not(:disabled), &.active:not(:disabled) {
     text-decoration: none !important;
     color: #000 !important;
   }
@@ -78,7 +82,7 @@
 .btn-secondary {
   @include button-variant($qg-blue, $qg-blue);
   color: #fff;
-  a, &:focus, &:hover, &:link, &:visited, &:active {
+  a, &:focus, &:hover, &:link, &:visited, &:active, &.focus, &.hover, &.link, &.visited, &.active {
     color: #fff !important;
     text-decoration: none !important;
   }
@@ -87,10 +91,14 @@
 .btn-default {
   @include button-variant($qg-dark-grey, $qg-dark-grey);
   color: #fff;
-  a, &:focus, &:hover, &:link, &:visited, &:active {
+  a, &:focus, &:hover, &:link, &:visited, &:active, &.focus, &.hover, &.link, &.visited, &.active {
     color: #fff !important;
     text-decoration: none !important;
   }
+}
+
+.btn-link {
+  @extend .btn-link;
 }
 
 .qg-btn {
@@ -99,7 +107,7 @@
     color: $qg-outline-dark;
     background-color: transparent !important;
     border:3px solid $qg-outline-dark;
-    &:hover, &:active, &:focus{
+    &:hover:not(:disabled), &:active:not(:disabled), &:focus:not(:disabled), &.hover:not(:disabled), &.active:not(:disabled), &.focus:not(:disabled) {
       border:3px solid $qg-outline-dark-hover;
       color: $qg-outline-dark-hover !important;
       text-decoration: underline;
@@ -109,7 +117,7 @@
     color: #ffffff !important;
     background-color: transparent !important;
     border:3px solid #ffffff;
-    &:hover, &:active, &:focus{
+    &:hover, &:active, &:focus, &.hover, &.active, &.focus {
       text-decoration: underline;
     }
   }

--- a/src/stories/components/Accordion/Accordion.stories.mdx
+++ b/src/stories/components/Accordion/Accordion.stories.mdx
@@ -1,5 +1,7 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
+import { Grid } from "../../decorators";
+
 import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "./templates/Default.html";
@@ -7,6 +9,7 @@ import Subtitle from "./templates/Subtitle.html";
 import Icon from "./templates/Icon.html";
 import Expandable from "./templates/Expandable.html";
 import Mobile from "./templates/Default.html";
+import States from "./templates/States.html";
 
 <Meta title="Components/Accordion" />
 
@@ -34,6 +37,21 @@ import Mobile from "./templates/Default.html";
 
 <Canvas withSource="open">
   <Story name="Expandable">{() => Expandable}</Story>
+</Canvas>
+
+## States
+
+<Canvas withSource="close">
+  <Story name="States"
+    decorators={[Grid(2)]}
+    parameters={{
+      docs: {
+        source: {
+          code: States,
+        },
+      }
+    }}
+  >{() => States}</Story>
 </Canvas>
 
 ## Mobile

--- a/src/stories/components/Accordion/Accordion.stories.mdx
+++ b/src/stories/components/Accordion/Accordion.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "./templates/Default.html";
 import Subtitle from "./templates/Subtitle.html";
@@ -39,7 +39,7 @@ import Mobile from "./templates/Default.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>
     {() => Mobile}
   </Story>
 </Canvas>

--- a/src/stories/components/Accordion/Accordion.stories.mdx
+++ b/src/stories/components/Accordion/Accordion.stories.mdx
@@ -1,9 +1,12 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
 import Default from "./templates/Default.html";
 import Subtitle from "./templates/Subtitle.html";
 import Icon from "./templates/Icon.html";
 import Expandable from "./templates/Expandable.html";
+import Mobile from "./templates/Default.html";
 
 <Meta title="Components/Accordion" />
 
@@ -31,4 +34,12 @@ import Expandable from "./templates/Expandable.html";
 
 <Canvas withSource="open">
   <Story name="Expandable">{() => Expandable}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>
+    {() => Mobile}
+  </Story>
 </Canvas>

--- a/src/stories/components/Accordion/templates/States.html
+++ b/src/stories/components/Accordion/templates/States.html
@@ -1,0 +1,108 @@
+<span>Collapsed</span>
+<span>Expanded</span>
+<section
+  class="qg-accordion qg-dark-accordion qg-accordion-v2"
+  aria-label="Default accordion (dark style)"
+>
+  <article>
+    <button class="acc-heading qg-accordion--closed">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">default</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249907">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--closed hover">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">hover</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249907">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--closed focus">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">focus</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249907">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--closed active">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">active</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249907">
+      <p>Accordion content</p>
+    </div>
+  </article>
+</section>
+<section
+  class="qg-accordion qg-dark-accordion qg-accordion-v2"
+  aria-label="Default accordion (dark style)"
+>
+  <article>
+    <button class="acc-heading qg-accordion--open" aria-expanded="true">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">default</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249915">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--open hover" aria-expanded="true">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">hover</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249915">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--open focus" aria-expanded="true">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">focus</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249915">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--open active" aria-expanded="true">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">active</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249915">
+      <p>Accordion content</p>
+    </div>
+  </article>
+</section>

--- a/src/stories/components/Buttons/Buttons.stories.mdx
+++ b/src/stories/components/Buttons/Buttons.stories.mdx
@@ -1,9 +1,12 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
+import { Grid } from "../../decorators";
+
 import Primary from "./templates/Primary.html";
 import Secondary from "./templates/Secondary.html";
 import Tertiary from "./templates/Tertiary.html";
 import Loading from "./templates/Loading.html";
+import States from "./templates/States.html";
 
 <Meta title="Components/Buttons" />
 
@@ -31,4 +34,22 @@ import Loading from "./templates/Loading.html";
 
 <Canvas withSource="open">
   <Story name="Loading">{() => Loading}</Story>
+</Canvas>
+
+## States
+
+<Canvas withSource="close">
+  <Story
+    name="States"
+    decorators={[Grid(5)]}
+    parameters={{
+      docs: {
+        source: {
+          code: States,
+        },
+      }
+    }}
+  >
+    {() => States}
+  </Story>
 </Canvas>

--- a/src/stories/components/Buttons/templates/States.html
+++ b/src/stories/components/Buttons/templates/States.html
@@ -1,0 +1,36 @@
+<span>default</span>
+<span>hover</span>
+<span>focus</span>
+<span>active</span>
+<span>disabled</span>
+
+<button type="button" class="qg-btn btn-primary">btn-primary</button>
+<button type="button" class="qg-btn btn-primary hover">btn-primary</button>
+<button type="button" class="qg-btn btn-primary focus">btn-primary</button>
+<button type="button" class="qg-btn btn-primary active">btn-primary</button>
+<button type="button" class="qg-btn btn-primary" disabled>btn-primary</button>
+
+<button type="button" class="qg-btn btn-secondary">btn-secondary</button>
+<button type="button" class="qg-btn btn-secondary hover">btn-secondary</button>
+<button type="button" class="qg-btn btn-secondary focus">btn-secondary</button>
+<button type="button" class="qg-btn btn-secondary active">btn-secondary</button>
+<button type="button" class="qg-btn btn-secondary" disabled>btn-secondary</button>
+
+<button type="button" class="qg-btn btn-default">btn-default</button>
+<button type="button" class="qg-btn btn-default hover">btn-default</button>
+<button type="button" class="qg-btn btn-default focus">btn-default</button>
+<button type="button" class="qg-btn btn-default active">btn-default</button>
+<button type="button" class="qg-btn btn-default" disabled>btn-default</button>
+
+<button type="button" class="qg-btn btn-outline-dark">btn-outline-dark</button>
+<button type="button" class="qg-btn btn-outline-dark hover">btn-outline-dark</button>
+<button type="button" class="qg-btn btn-outline-dark focus">btn-outline-dark</button>
+<button type="button" class="qg-btn btn-outline-dark active">btn-outline-dark</button>
+<button type="button" class="qg-btn btn-outline-dark" disabled>btn-outline-dark</button>
+
+<button type="button" class="qg-btn btn-link">btn-link</button>
+<button type="button" class="qg-btn btn-link hover">btn-link</button>
+<button type="button" class="qg-btn btn-link focus">btn-link</button>
+<button type="button" class="qg-btn btn-link active">btn-link</button>
+<button type="button" class="qg-btn btn-link" disabled>btn-link</button>
+

--- a/src/stories/decorators/Grid.js
+++ b/src/stories/decorators/Grid.js
@@ -1,0 +1,7 @@
+import { DecoratorBase } from './DecoratorBase';
+
+export const Grid = (colNum = 5) => (Child) => {
+  const elem = DecoratorBase('div', Child);
+  elem.style = `display: grid; gap: 1rem; grid-template-columns: repeat(${colNum}, 1fr); `;
+  return elem;
+};

--- a/src/stories/decorators/index.js
+++ b/src/stories/decorators/index.js
@@ -1,4 +1,5 @@
 export * from './DecoratorBase';
+export * from './Grid';
 export * from './QgContent';
 export * from './QgPrimary';
 export * from './QgPrimaryContent';

--- a/src/stories/helpers/getMobileProps.js
+++ b/src/stories/helpers/getMobileProps.js
@@ -1,9 +1,16 @@
 import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 export const getCanvasMobileProps = () => ({ style: INITIAL_VIEWPORTS.iphone12.styles });
+
 export const getStoryMobileParameters = () => ({
   viewport: {
     viewports: INITIAL_VIEWPORTS,
     defaultViewport: 'iphone12',
   },
+  docs: {
+    // Opt-out of inline rendering
+    inlineStories: false,
+  },
 });
+
+export const getStoryMobileHeight = () => INITIAL_VIEWPORTS.iphone12.styles.height;

--- a/src/stories/helpers/getMobileProps.js
+++ b/src/stories/helpers/getMobileProps.js
@@ -1,0 +1,9 @@
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
+
+export const getCanvasMobileProps = () => ({ style: INITIAL_VIEWPORTS.iphone12.styles });
+export const getStoryMobileParameters = () => ({
+  viewport: {
+    viewports: INITIAL_VIEWPORTS,
+    defaultViewport: 'iphone12',
+  },
+});

--- a/src/stories/helpers/index.js
+++ b/src/stories/helpers/index.js
@@ -1,0 +1,1 @@
+export * from './getMobileProps';

--- a/src/stories/layout/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/src/stories/layout/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -1,0 +1,29 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import BreadcrumbAgency from "./templates/BreadcrumbAgency.html";
+import BreadcrumbGlobal from "./templates/BreadcrumbGlobal.html";
+import Mobile from "./templates/BreadcrumbGlobal.html";
+
+<Meta title="Layout/Breadcrumbs" />
+
+# Breadcrumbs
+
+## Breadcrumb Global
+
+<Canvas withSource="close">
+  <Story name="BreadcrumbGlobal">{() => BreadcrumbGlobal}</Story>
+</Canvas>
+
+## Breadcrumb Agency
+
+<Canvas withSource="close">
+  <Story name="BreadcrumbAgency">{() => BreadcrumbAgency}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>

--- a/src/stories/layout/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/src/stories/layout/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import BreadcrumbAgency from "./templates/BreadcrumbAgency.html";
 import BreadcrumbGlobal from "./templates/BreadcrumbGlobal.html";
@@ -25,5 +25,5 @@ import Mobile from "./templates/BreadcrumbGlobal.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/layout/Breadcrumbs/templates/BreadcrumbAgency.html
+++ b/src/stories/layout/Breadcrumbs/templates/BreadcrumbAgency.html
@@ -1,0 +1,1 @@
+<!--#include virtual="/assets/includes-local/breadcrumbs/breadcrumb-agency.html"-->

--- a/src/stories/layout/Breadcrumbs/templates/BreadcrumbGlobal.html
+++ b/src/stories/layout/Breadcrumbs/templates/BreadcrumbGlobal.html
@@ -1,0 +1,1 @@
+<!--#include virtual="/assets/includes-local/breadcrumbs/breadcrumb-global.html"-->

--- a/src/stories/layout/Footer/Footer.stories.mdx
+++ b/src/stories/layout/Footer/Footer.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "./templates/Footer.html";
 import Mobile from "./templates/Footer.html";
@@ -18,5 +18,5 @@ import Mobile from "./templates/Footer.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/layout/Footer/Footer.stories.mdx
+++ b/src/stories/layout/Footer/Footer.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import Default from "./templates/Footer.html";
+import Mobile from "./templates/Footer.html";
+
+<Meta title="Layout/Footer" />
+
+# Footer
+
+## Default
+
+<Canvas withSource="close">
+  <Story name="Default">{() => Default}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>

--- a/src/stories/layout/Footer/templates/Footer.html
+++ b/src/stories/layout/Footer/templates/Footer.html
@@ -1,0 +1,1 @@
+<!--#include virtual="/assets/includes-local/footer/footer.html"-->

--- a/src/stories/layout/Header/Header.stories.mdx
+++ b/src/stories/layout/Header/Header.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import Default from "./templates/Header.html";
+import Mobile from "./templates/Header.html";
+
+<Meta title="Layout/Header" />
+
+# Header
+
+## Default
+
+<Canvas withSource="close">
+  <Story name="Default">{() => Default}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>

--- a/src/stories/layout/Header/Header.stories.mdx
+++ b/src/stories/layout/Header/Header.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "./templates/Header.html";
 import Mobile from "./templates/Header.html";
@@ -18,5 +18,5 @@ import Mobile from "./templates/Header.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/layout/Header/templates/Header.html
+++ b/src/stories/layout/Header/templates/Header.html
@@ -1,0 +1,1 @@
+<!--#include virtual="/assets/includes-local/header/header.html"-->

--- a/src/stories/templates/AggregationPage/AggregationPage.stories.mdx
+++ b/src/stories/templates/AggregationPage/AggregationPage.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import Default from "../../../template-pages/aggregation-page.html";
+import Mobile from "../../../template-pages/aggregation-page.html";
+
+<Meta title="Templates/AggregationPage" />
+
+# Aggregation Page
+
+## Default
+
+<Canvas withSource="close">
+  <Story name="Default">{() => Default}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>

--- a/src/stories/templates/AggregationPage/AggregationPage.stories.mdx
+++ b/src/stories/templates/AggregationPage/AggregationPage.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "../../../template-pages/aggregation-page.html";
 import Mobile from "../../../template-pages/aggregation-page.html";
@@ -18,5 +18,5 @@ import Mobile from "../../../template-pages/aggregation-page.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/ApplicationPage copy/ApplicationPage.stories.mdx
+++ b/src/stories/templates/ApplicationPage copy/ApplicationPage.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import Default from "../../../template-pages/application-page.html";
+import Mobile from "../../../template-pages/application-page.html";
+
+<Meta title="Templates/ApplicationPage" />
+
+# Application Page
+
+## Default
+
+<Canvas withSource="close">
+  <Story name="Default">{() => Default}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>

--- a/src/stories/templates/ApplicationPage copy/ApplicationPage.stories.mdx
+++ b/src/stories/templates/ApplicationPage copy/ApplicationPage.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "../../../template-pages/application-page.html";
 import Mobile from "../../../template-pages/application-page.html";
@@ -18,5 +18,5 @@ import Mobile from "../../../template-pages/application-page.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/ContentPage/ContentPage.stories.mdx
+++ b/src/stories/templates/ContentPage/ContentPage.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import Default from "../../../template-pages/content-page.html";
+import Mobile from "../../../template-pages/content-page.html";
+
+<Meta title="Templates/ContentPage" />
+
+# Content Page
+
+## Default
+
+<Canvas withSource="close">
+  <Story name="Default">{() => Default}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>

--- a/src/stories/templates/ContentPage/ContentPage.stories.mdx
+++ b/src/stories/templates/ContentPage/ContentPage.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "../../../template-pages/content-page.html";
 import Mobile from "../../../template-pages/content-page.html";
@@ -18,5 +18,5 @@ import Mobile from "../../../template-pages/content-page.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/ContentPageNoAsides/ContentPageNoAsides.stories.mdx
+++ b/src/stories/templates/ContentPageNoAsides/ContentPageNoAsides.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import Default from "../../../template-pages/content-page-no-asides.html";
+import Mobile from "../../../template-pages/content-page-no-asides.html";
+
+<Meta title="Templates/ContentPageNoAsides" />
+
+# Content Page No Asides
+
+## Default
+
+<Canvas withSource="close">
+  <Story name="Default">{() => Default}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>

--- a/src/stories/templates/ContentPageNoAsides/ContentPageNoAsides.stories.mdx
+++ b/src/stories/templates/ContentPageNoAsides/ContentPageNoAsides.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "../../../template-pages/content-page-no-asides.html";
 import Mobile from "../../../template-pages/content-page-no-asides.html";
@@ -18,5 +18,5 @@ import Mobile from "../../../template-pages/content-page-no-asides.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/ContentPageWithoutLocation/ContentPageWithoutLocation.stories.mdx
+++ b/src/stories/templates/ContentPageWithoutLocation/ContentPageWithoutLocation.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import Default from "../../../template-pages/content-page-without-location.html";
+import Mobile from "../../../template-pages/content-page-without-location.html";
+
+<Meta title="Templates/ContentPageWithoutLocation" />
+
+# Content Page Without Location
+
+## Default
+
+<Canvas withSource="close">
+  <Story name="Default">{() => Default}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>

--- a/src/stories/templates/ContentPageWithoutLocation/ContentPageWithoutLocation.stories.mdx
+++ b/src/stories/templates/ContentPageWithoutLocation/ContentPageWithoutLocation.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "../../../template-pages/content-page-without-location.html";
 import Mobile from "../../../template-pages/content-page-without-location.html";
@@ -18,5 +18,5 @@ import Mobile from "../../../template-pages/content-page-without-location.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/IndexPage/IndexPage.stories.mdx
+++ b/src/stories/templates/IndexPage/IndexPage.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import Default from "../../../template-pages/index-page.html";
+import Mobile from "../../../template-pages/index-page.html";
+
+<Meta title="Templates/IndexPage" />
+
+# Index Page
+
+## Default
+
+<Canvas withSource="close">
+  <Story name="Default">{() => Default}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>

--- a/src/stories/templates/IndexPage/IndexPage.stories.mdx
+++ b/src/stories/templates/IndexPage/IndexPage.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "../../../template-pages/index-page.html";
 import Mobile from "../../../template-pages/index-page.html";
@@ -18,5 +18,5 @@ import Mobile from "../../../template-pages/index-page.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/TopicIndexPage/TopicIndexPage.stories.mdx
+++ b/src/stories/templates/TopicIndexPage/TopicIndexPage.stories.mdx
@@ -1,6 +1,6 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "../../../template-pages/topic-index-page.html";
 import Mobile from "../../../template-pages/topic-index-page.html";
@@ -18,5 +18,5 @@ import Mobile from "../../../template-pages/topic-index-page.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/TopicIndexPage/TopicIndexPage.stories.mdx
+++ b/src/stories/templates/TopicIndexPage/TopicIndexPage.stories.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from "@storybook/addon-docs";
+
+import { getCanvasMobileProps, getStoryMobileParameters } from "../../helpers";
+
+import Default from "../../../template-pages/topic-index-page.html";
+import Mobile from "../../../template-pages/topic-index-page.html";
+
+<Meta title="Templates/TopicIndexPage" />
+
+# Topic Index Page
+
+## Default
+
+<Canvas withSource="close">
+  <Story name="Default">{() => Default}</Story>
+</Canvas>
+
+## Mobile
+
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()}>{() => Mobile}</Story>
+</Canvas>


### PR DESCRIPTION
Due to the size of this change, it break it up into the following parts:
Part 1 - install Storybook infrastructure
Part 2 - create stories for foundations (typography, color, etc.)
Part 3 - create stories for components - first batch
Part 4 - create stories for templates
Part 5 - integrate with Chromatic (trial)

### Part 4 - create stories for templates and layout
major changes:
- replicate stories from [forgov templates doc](https://www.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/templates).
- add stories and helpers to display component in mobile view (also generate mobile view snapshot in visual testing).
- add SSI support to Storybook's Webpack settings so it can render existing HTML template directly.