### PR TITLE
Add example stories to show states of a component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
+    "storybook-addon-pseudo-states",
   ],
   staticDirs: ["../build"],
   previewMainTemplate: "./.storybook/previewMainTemplate.ejs",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "run-sequence": "^1.1.5",
     "sass": "^1.38.0",
     "sass-migrator": "^1.5.1",
+    "storybook-addon-pseudo-states": "^1.15.1",
     "string-replace-loader": "^2.3.0",
     "style-loader": "^0.17.0",
     "terser-webpack-plugin": "^3.0.3",

--- a/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
+++ b/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
@@ -26,7 +26,7 @@
           font-weight: bold;
           padding-right: 1.8rem;
         }
-        &:hover {
+        &:hover, &.hover {
           .title{
             text-decoration: none;
             color: $qg-dark-grey-darker;
@@ -69,7 +69,7 @@
       }
     }
   }
-  button:focus{
+  button:focus, button.focus {
     outline: 2px solid #0096d6 !important;
     outline-offset: 2px;
     z-index: 100;
@@ -106,7 +106,7 @@
     display: inline-block;
   }
   .expand, .collapse, label[for="expand"], label[for="collapse"] {
-    &:hover {
+    &:hover, &.hover {
       text-decoration: underline !important;
     }
   }
@@ -233,10 +233,11 @@
 
 // IOS safari specific styles
 @media not all and (min-resolution:.001dpcm) {
-  .qg-accordion .acc-heading:focus {
+  .qg-accordion .acc-heading:focus, .qg-accordion .acc-heading.focus {
     outline: 2px solid $qg-blue;
   }
-  .qg-accordion .expand:focus, .qg-accordion .expand:active, .qg-accordion .collapse:focus, .qg-accordion .collapse:active{
+  .qg-accordion .expand:focus, .qg-accordion .expand:active, .qg-accordion .collapse:focus, .qg-accordion .collapse:active, 
+  .qg-accordion .expand.focus, .qg-accordion .expand.active, .qg-accordion .collapse.focus, .qg-accordion .collapse.active {
     outline: 2px solid $qg-blue !important;
     outline-offset: -2px;
   }

--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -1,3 +1,7 @@
+@mixin hover() {
+  &:hover:not(:disabled, .disabled), &.hover:not(:disabled, .disabled) { @content; }
+}
+
 .btn-global-primary{
   color: #fff;
   background-color: $qg-global-primary-dark-grey;
@@ -9,13 +13,13 @@
     padding: 9px 11px;
   }
 
-  &:hover, &:focus {
+  &:hover, &:focus, &.hover, &.focus {
     text-decoration: underline;
     color: #fff;
     background-color: $qg-global-primary-dark-grey;
   }
 
-  &:focus {
+  &:focus, &.focus {
     outline: 1px dotted #000;
     outline: 5px auto -webkit-focus-ring-color;
   }
@@ -34,12 +38,12 @@
     padding: 9px 11px;
   }
 
-  &:hover, &:focus {
+  &:hover, &:focus, &.hover, &.focus {
     color: $qg-global-primary-dark-grey;
     text-decoration: underline;
   }
 
-  &:focus {
+  &:focus, &.focus {
     outline: 1px dotted #000;
     outline: 5px auto -webkit-focus-ring-color;
   }
@@ -55,12 +59,12 @@
   padding: 7px 24px;
   text-decoration: none;
 
-  &:hover, &:focus {
+  &:hover, &:focus, &.hover, &.focus {
     color: #fff;
     text-decoration: underline;
   }
 
-  &:focus {
+  &:focus, &.focus {
     outline: 1px dotted #000;
     outline: 5px auto -webkit-focus-ring-color;
   }
@@ -69,7 +73,7 @@
 .btn-primary{
   @include button-variant($qg-light-green, $qg-light-green, lighten($qg-light-green, 7.5%), $hover-border: $qg-light-green, $active-background:$qg-light-green, $active-border: $qg-light-green);
   color: #000;
-  a, &:focus, &:hover, &:link, &:visited, &:active {
+  a, &:focus:not(:disabled), &:hover:not(:disabled), &:link:not(:disabled), &:visited:not(:disabled), &:active:not(:disabled), &.focus:not(:disabled), &.hover:not(:disabled), &.link:not(:disabled), &.visited:not(:disabled), &.active:not(:disabled) {
     text-decoration: none !important;
     color: #000 !important;
   }
@@ -78,7 +82,7 @@
 .btn-secondary {
   @include button-variant($qg-blue, $qg-blue);
   color: #fff;
-  a, &:focus, &:hover, &:link, &:visited, &:active {
+  a, &:focus, &:hover, &:link, &:visited, &:active, &.focus, &.hover, &.link, &.visited, &.active {
     color: #fff !important;
     text-decoration: none !important;
   }
@@ -87,10 +91,14 @@
 .btn-default {
   @include button-variant($qg-dark-grey, $qg-dark-grey);
   color: #fff;
-  a, &:focus, &:hover, &:link, &:visited, &:active {
+  a, &:focus, &:hover, &:link, &:visited, &:active, &.focus, &.hover, &.link, &.visited, &.active {
     color: #fff !important;
     text-decoration: none !important;
   }
+}
+
+.btn-link {
+  @extend .btn-link;
 }
 
 .qg-btn {
@@ -99,7 +107,7 @@
     color: $qg-outline-dark;
     background-color: transparent !important;
     border:3px solid $qg-outline-dark;
-    &:hover, &:active, &:focus{
+    &:hover:not(:disabled), &:active:not(:disabled), &:focus:not(:disabled), &.hover:not(:disabled), &.active:not(:disabled), &.focus:not(:disabled) {
       border:3px solid $qg-outline-dark-hover;
       color: $qg-outline-dark-hover !important;
       text-decoration: underline;
@@ -109,7 +117,7 @@
     color: #ffffff !important;
     background-color: transparent !important;
     border:3px solid #ffffff;
-    &:hover, &:active, &:focus{
+    &:hover, &:active, &:focus, &.hover, &.active, &.focus {
       text-decoration: underline;
     }
   }

--- a/src/stories/components/Accordion/Accordion.stories.mdx
+++ b/src/stories/components/Accordion/Accordion.stories.mdx
@@ -1,5 +1,7 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
+import { Grid } from "../../decorators";
+
 import { getCanvasMobileProps, getStoryMobileParameters, getStoryMobileHeight } from "../../helpers";
 
 import Default from "./templates/Default.html";
@@ -7,6 +9,7 @@ import Subtitle from "./templates/Subtitle.html";
 import Icon from "./templates/Icon.html";
 import Expandable from "./templates/Expandable.html";
 import Mobile from "./templates/Default.html";
+import States from "./templates/States.html";
 
 <Meta title="Components/Accordion" />
 
@@ -34,6 +37,21 @@ import Mobile from "./templates/Default.html";
 
 <Canvas withSource="open">
   <Story name="Expandable">{() => Expandable}</Story>
+</Canvas>
+
+## States
+
+<Canvas withSource="close">
+  <Story name="States"
+    decorators={[Grid(2)]}
+    parameters={{
+      docs: {
+        source: {
+          code: States,
+        },
+      }
+    }}
+  >{() => States}</Story>
 </Canvas>
 
 ## Mobile

--- a/src/stories/components/Accordion/templates/States.html
+++ b/src/stories/components/Accordion/templates/States.html
@@ -1,0 +1,108 @@
+<span>Collapsed</span>
+<span>Expanded</span>
+<section
+  class="qg-accordion qg-dark-accordion qg-accordion-v2"
+  aria-label="Default accordion (dark style)"
+>
+  <article>
+    <button class="acc-heading qg-accordion--closed">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">default</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249907">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--closed hover">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">hover</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249907">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--closed focus">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">focus</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249907">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--closed active">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">active</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249907">
+      <p>Accordion content</p>
+    </div>
+  </article>
+</section>
+<section
+  class="qg-accordion qg-dark-accordion qg-accordion-v2"
+  aria-label="Default accordion (dark style)"
+>
+  <article>
+    <button class="acc-heading qg-accordion--open" aria-expanded="true">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">default</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249915">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--open hover" aria-expanded="true">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">hover</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249915">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--open focus" aria-expanded="true">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">focus</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249915">
+      <p>Accordion content</p>
+    </div>
+  </article>
+  <article>
+    <button class="acc-heading qg-accordion--open active" aria-expanded="true">
+      <a class="qg-accordion--ga" data-analytics-link-group="accordion title - Accordion title">
+        <span class="accordion-label">
+          <span class="title">active</span>
+        </span>
+      </a>
+    </button>
+    <div class="collapsing-section" id="id-panel-1-249915">
+      <p>Accordion content</p>
+    </div>
+  </article>
+</section>

--- a/src/stories/components/Buttons/Buttons.stories.mdx
+++ b/src/stories/components/Buttons/Buttons.stories.mdx
@@ -1,9 +1,12 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
+import { Grid } from "../../decorators";
+
 import Primary from "./templates/Primary.html";
 import Secondary from "./templates/Secondary.html";
 import Tertiary from "./templates/Tertiary.html";
 import Loading from "./templates/Loading.html";
+import States from "./templates/States.html";
 
 <Meta title="Components/Buttons" />
 
@@ -31,4 +34,22 @@ import Loading from "./templates/Loading.html";
 
 <Canvas withSource="open">
   <Story name="Loading">{() => Loading}</Story>
+</Canvas>
+
+## States
+
+<Canvas withSource="close">
+  <Story
+    name="States"
+    decorators={[Grid(5)]}
+    parameters={{
+      docs: {
+        source: {
+          code: States,
+        },
+      }
+    }}
+  >
+    {() => States}
+  </Story>
 </Canvas>

--- a/src/stories/components/Buttons/templates/States.html
+++ b/src/stories/components/Buttons/templates/States.html
@@ -1,0 +1,36 @@
+<span>default</span>
+<span>hover</span>
+<span>focus</span>
+<span>active</span>
+<span>disabled</span>
+
+<button type="button" class="qg-btn btn-primary">btn-primary</button>
+<button type="button" class="qg-btn btn-primary hover">btn-primary</button>
+<button type="button" class="qg-btn btn-primary focus">btn-primary</button>
+<button type="button" class="qg-btn btn-primary active">btn-primary</button>
+<button type="button" class="qg-btn btn-primary" disabled>btn-primary</button>
+
+<button type="button" class="qg-btn btn-secondary">btn-secondary</button>
+<button type="button" class="qg-btn btn-secondary hover">btn-secondary</button>
+<button type="button" class="qg-btn btn-secondary focus">btn-secondary</button>
+<button type="button" class="qg-btn btn-secondary active">btn-secondary</button>
+<button type="button" class="qg-btn btn-secondary" disabled>btn-secondary</button>
+
+<button type="button" class="qg-btn btn-default">btn-default</button>
+<button type="button" class="qg-btn btn-default hover">btn-default</button>
+<button type="button" class="qg-btn btn-default focus">btn-default</button>
+<button type="button" class="qg-btn btn-default active">btn-default</button>
+<button type="button" class="qg-btn btn-default" disabled>btn-default</button>
+
+<button type="button" class="qg-btn btn-outline-dark">btn-outline-dark</button>
+<button type="button" class="qg-btn btn-outline-dark hover">btn-outline-dark</button>
+<button type="button" class="qg-btn btn-outline-dark focus">btn-outline-dark</button>
+<button type="button" class="qg-btn btn-outline-dark active">btn-outline-dark</button>
+<button type="button" class="qg-btn btn-outline-dark" disabled>btn-outline-dark</button>
+
+<button type="button" class="qg-btn btn-link">btn-link</button>
+<button type="button" class="qg-btn btn-link hover">btn-link</button>
+<button type="button" class="qg-btn btn-link focus">btn-link</button>
+<button type="button" class="qg-btn btn-link active">btn-link</button>
+<button type="button" class="qg-btn btn-link" disabled>btn-link</button>
+

--- a/src/stories/decorators/Grid.js
+++ b/src/stories/decorators/Grid.js
@@ -1,0 +1,7 @@
+import { DecoratorBase } from './DecoratorBase';
+
+export const Grid = (colNum = 5) => (Child) => {
+  const elem = DecoratorBase('div', Child);
+  elem.style = `display: grid; gap: 1rem; grid-template-columns: repeat(${colNum}, 1fr); `;
+  return elem;
+};

--- a/src/stories/decorators/index.js
+++ b/src/stories/decorators/index.js
@@ -1,4 +1,5 @@
 export * from './DecoratorBase';
+export * from './Grid';
 export * from './QgContent';
 export * from './QgPrimary';
 export * from './QgPrimaryContent';


### PR DESCRIPTION
Add example stories to show states of a component, so they different states of a component can be testable in visual testing.
- add storybook pseudo class plugin
- add `states` stories for Buttons and Accordion
- Modified Button class to show pseudo style (align to Bootstrap implementation)
- add `Grid` Storybook decorator