### PR TITLE
[QOL-9431] exclude links with the 'button' class from the usual styling

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -23,7 +23,7 @@ const buildHours = (buildDate.getHours() + 1) < 10 ? '0' + (buildDate.getHours()
 const buildMinutes = buildDate.getMinutes() < 10 ? '0' + buildDate.getMinutes() : buildDate.getMinutes();
 const banner = '/*! SWE' +
   ' ' + pjson.version +
-  ' ' + buildDate.getFullYear() + buildMonth + buildDay + 'T' + buildHours + buildMinutes +	' */' +
+  ' ' + buildDate.getFullYear() + buildMonth + buildDay + 'T' + buildHours + buildMinutes + ' */' +
   '\n';
 
 /* CLEAN TASKS */

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -18,6 +18,7 @@
       float: left;
     }
     a {
+      text-decoration-line: none !important;
       &:hover {
         img {
           border: 1px solid #06c;

--- a/src/assets/_project/_blocks/layout/breadcrumbs/breadcrumbs.js
+++ b/src/assets/_project/_blocks/layout/breadcrumbs/breadcrumbs.js
@@ -1,23 +1,23 @@
 (function () {
-    $('.qg-global-breadcrumb .qg-breadcrumb-list').each(function () {
-        var breadcrumbLength = $(this).find('.qg-breadcrumb-list-item').length;
-        if (breadcrumbLength > 4) {
-            for (var i = 0; i < breadcrumbLength; i++) {
-                if (i > 1 && i < breadcrumbLength - 2) {
-                    $(this).find('.qg-breadcrumb-list-item').eq(i).addClass('shortened');
-                    $(this).find('.qg-breadcrumb-list-item').eq(i).find('.qg-breadcrumb-list-item__link').attr('tabindex', '-1');
-                    $(this).find('.qg-breadcrumb-list-item').eq(i).find('.qg-breadcrumb-list-item__link').attr('data-analytics-link-group', 'qg-breadcrumb-revealed-link');
-                } else {
-                    $(this).find('.qg-breadcrumb-list-item').eq(i).find('.qg-breadcrumb-list-item__link').attr('data-analytics-link-group', 'qg-breadcrumb-link');
-                }
-            }
-            $(this).find('.qg-breadcrumb-list-item').eq(1).after("<li class='qg-breadcrumb-list-item shorten'><button class='qg-breadcrumb-toggle' aria-label='Expand the breadcrumbs' data-analytics-link-group='qg-breadcrumb-ellipsis'>[...]</button></li>");
+  $('.qg-global-breadcrumb .qg-breadcrumb-list').each(function () {
+    var breadcrumbLength = $(this).find('.qg-breadcrumb-list-item').length;
+    if (breadcrumbLength > 4) {
+      for (var i = 0; i < breadcrumbLength; i++) {
+        if (i > 1 && i < breadcrumbLength - 2) {
+          $(this).find('.qg-breadcrumb-list-item').eq(i).addClass('shortened');
+          $(this).find('.qg-breadcrumb-list-item').eq(i).find('.qg-breadcrumb-list-item__link').attr('tabindex', '-1');
+          $(this).find('.qg-breadcrumb-list-item').eq(i).find('.qg-breadcrumb-list-item__link').attr('data-analytics-link-group', 'qg-breadcrumb-revealed-link');
+        } else {
+          $(this).find('.qg-breadcrumb-list-item').eq(i).find('.qg-breadcrumb-list-item__link').attr('data-analytics-link-group', 'qg-breadcrumb-link');
         }
+      }
+      $(this).find('.qg-breadcrumb-list-item').eq(1).after("<li class='qg-breadcrumb-list-item shorten'><button class='qg-breadcrumb-toggle' aria-label='Expand the breadcrumbs' data-analytics-link-group='qg-breadcrumb-ellipsis'>[...]</button></li>");
+    }
 
-        $('.qg-breadcrumb-toggle').on('click', function () {
-            $('.qg-breadcrumb-list-item').removeClass('shortened');
-            $('.qg-breadcrumb-list-item__link').attr('tabindex', '0');
-            $('.qg-breadcrumb-list').addClass('expanded');
-        });
+    $('.qg-breadcrumb-toggle').on('click', function () {
+      $('.qg-breadcrumb-list-item').removeClass('shortened');
+      $('.qg-breadcrumb-list-item__link').attr('tabindex', '0');
+      $('.qg-breadcrumb-list').addClass('expanded');
     });
-  })();
+  });
+})();

--- a/src/assets/_project/_blocks/layout/content/_content.scss
+++ b/src/assets/_project/_blocks/layout/content/_content.scss
@@ -7,7 +7,7 @@
       display: block;
     }
   }
-  a:not(.qg-btn):not(.btn){
+  a:not(.qg-btn):not(.btn):not(.button){
     @include qg-link-styles__default
   }
   .print-content-link{

--- a/src/assets/_project/_blocks/utils/qg-ajax-call.js
+++ b/src/assets/_project/_blocks/utils/qg-ajax-call.js
@@ -12,7 +12,7 @@
       success: callback,
       error: () => {
         console.log(errorMsg);
-      }
+      },
     });
   };
 }(jQuery, qg.swe));

--- a/src/stories/components/Buttons/Buttons.stories.mdx
+++ b/src/stories/components/Buttons/Buttons.stories.mdx
@@ -8,6 +8,7 @@ import Secondary from "./templates/Secondary.html";
 import Tertiary from "./templates/Tertiary.html";
 import Loading from "./templates/Loading.html";
 import States from "./templates/States.html";
+import Links from "./templates/Links.html";
 
 <Meta title="Components/Buttons" decorators={[QgPrimaryContent, QgContent]} />
 
@@ -50,5 +51,13 @@ import States from "./templates/States.html";
 <Canvas withSource="close">
   <Story name="States" decorators={[Grid(5)]} parameters={getDecoratedParameters(States)}>
     {() => States}
+  </Story>
+</Canvas>
+
+## Links
+
+<Canvas withSource="close">
+  <Story name="Links" decorators={[Grid(5)]} parameters={getDecoratedParameters(Links)}>
+    {() => Links}
   </Story>
 </Canvas>

--- a/src/stories/components/Buttons/templates/Links.html
+++ b/src/stories/components/Buttons/templates/Links.html
@@ -1,0 +1,15 @@
+<p class="actions">
+  <strong>
+    <a class="qg-btn button" href="http://example.com">'qg-btn' link</a>
+  </strong>
+</p>
+<p class="actions">
+  <strong>
+    <a class="btn button" href="http://example.com">'btn' link</a>
+  </strong>
+</p>
+<p class="actions">
+  <strong>
+    <a class="button" href="http://example.com">'button' link</a>
+  </strong>
+</p>


### PR DESCRIPTION
Same as the 'btn' and 'qg-btn' classes.

This should resolve eg the button text on /transport/boating/registration/recreational turning blue and the button background vanishing on focus.