### PR TITLE
QOL-9431 Split text-decoration into individual declarations

### DIFF
--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -99,8 +99,7 @@
 
 .btn-link {
   @include hover() {
-    color: $link-hover-color;
-    text-decoration: $link-hover-decoration;
+    @include link-hover;
   }
 }
 

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -38,10 +38,11 @@
 @mixin qg-link-styles__default {
   @include qg-global-link-styles {
     color: $qg-blue-dark;
-    text-decoration: $qg-link-decoration #457aa3;
+    @include qg-link-decoration;
+    text-decoration-color: #457aa3;
     &:hover,
     &.hover {
-      text-decoration: $qg-link-hover-decoration;
+      @include qg-link-hover-decoration;
     }
   }
 }
@@ -51,11 +52,11 @@
   @include qg-global-link-styles {
     color: $qg-blue-dark;
     &:link {
-      text-decoration: $qg-link-none-decoration;
+      @include qg-link-none-decoration;
     }
     &:hover,
     &.hover {
-      text-decoration: $qg-link-hover-decoration;
+      @include qg-link-hover-decoration;
     }
   }
 }
@@ -70,11 +71,11 @@
   @include qg-global-link-styles {
     color: $qg-global-primary-darker-grey;
     &:link {
-      text-decoration: $qg-link-none-decoration;
+      @include qg-link-none-decoration;
     }
     &:hover,
     &.hover {
-      text-decoration: $qg-link-hover-decoration;
+      @include qg-link-hover-decoration;
     }
   }
 }
@@ -83,11 +84,11 @@
   @include qg-global-link-styles {
     color: $qg-global-primary-darker-grey;
     &:link {
-      text-decoration: $qg-link-none-decoration;
+      @include qg-link-none-decoration;
     }
     &:hover,
     &.hover {
-      text-decoration: $qg-link-hover-decoration;
+      @include qg-link-hover-decoration;
     }
   }
 }
@@ -96,10 +97,11 @@
 @mixin qg-link-styles__theme-black {
   @include qg-global-link-styles {
     color: $qg-global-primary-darker-grey;
-    text-decoration: $qg-link-decoration #737678;
+    @include qg-link-decoration;
+    text-decoration-color: #737678;
     &:hover,
     &.hover {
-      text-decoration: $qg-link-hover-decoration;
+      @include qg-link-hover-decoration;
     }
   }
 }
@@ -113,10 +115,12 @@
 @mixin qg-link-styles__theme-white {
   @include qg-global-link-styles {
     color: #fff;
-    text-decoration: $qg-link-decoration rgba(255, 255, 255, 0.73);
+    @include qg-link-decoration;
+    text-decoration-color: rgba(255, 255, 255, 0.73);
     &:hover,
     &.hover {
-      text-decoration: $qg-link-hover-decoration #fff;
+      @include qg-link-hover-decoration;
+      text-decoration-color: #fff;
     }
   }
 }
@@ -126,11 +130,12 @@
   @include qg-global-link-styles {
     color: #fff;
     &:link {
-      text-decoration: $qg-link-none-decoration;
+      @include qg-link-none-decoration;
     }
     &:hover,
     &.hover {
-      text-decoration: $qg-link-hover-decoration #fff;
+      @include qg-link-hover-decoration;
+      text-decoration-color: #fff;
     }
   }
 }
@@ -147,7 +152,7 @@
 
   &:visited:hover {
     color: #80b;
-    text-decoration: $qg-link-hover-decoration;
+    @include qg-link-hover-decoration;
     text-decoration-color: #80b;
   }
 }

--- a/src/assets/_project/_blocks/layout/content/_location-setter.scss
+++ b/src/assets/_project/_blocks/layout/content/_location-setter.scss
@@ -47,7 +47,7 @@
 
     &-divider {
         @include rem(font-size, 12px);
-        color: $qg-global-primary-accesible-grey;
+        color: $qg-global-primary-accessible-grey;
         display: block;
         width: 100%;
         position: relative;
@@ -57,7 +57,7 @@
         &:before, &:after {
             content: "";
             position: absolute;
-            border-top: 1px solid $qg-global-primary-accesible-grey;
+            border-top: 1px solid $qg-global-primary-accessible-grey;
             width: 46%;
             top: 50%;
             transform: translateY(-50%);
@@ -145,7 +145,7 @@
         @include rem(font-size, 14px);
         background-color: transparent;
         border: 0;
-        color: $qg-global-primary-accesible-grey;
+        color: $qg-global-primary-accessible-grey;
         display: block;
         margin-top: 30px;
         padding: 0;

--- a/src/assets/_project/_blocks/layout/footer/_footer-feedback.scss
+++ b/src/assets/_project/_blocks/layout/footer/_footer-feedback.scss
@@ -136,7 +136,7 @@
     @include rem(font-size, 14px);
     background-color: transparent;
     border: 0;
-    color: $qg-global-primary-accesible-grey;
+    color: $qg-global-primary-accessible-grey;
     font-weight: normal;
     padding: 0;
     margin-top: 10px;
@@ -424,7 +424,7 @@
     @include rem(font-size, 14px);
     background-color: transparent;
     border: 0;
-    color: $qg-global-primary-accesible-grey;
+    color: $qg-global-primary-accessible-grey;
     font-weight: normal;
     padding: 0;
     margin-top: 10px;

--- a/src/assets/_project/_blocks/scss-general/_qg-css-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-css-variables.scss
@@ -16,7 +16,7 @@
 
   --qg-color-dark-grey-active: #{$qg-global-dark-grey-active};
   --qg-color-dark-grey-dark-active: #{$qg-global-dark-grey-dark-active};
-  --qg-color-primary-accesible-grey: #{$qg-global-primary-accesible-grey};
+  --qg-color-primary-accessible-grey: #{$qg-global-primary-accessible-grey};
   --qg-color-light-gray-dark: #{$qg-light-gray-dark};
 
   --qg-color-error: #{$qg-global-error};

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -259,7 +259,17 @@ $qg-twitter: #1da1f2;
 $qg-linkedin: #0077b5;
 
 // new link variables
-$qg-link-decoration: underline 0.5px solid !default;
-$qg-link-none-decoration: none 0.5px solid !default;
-$qg-link-hover-decoration: underline 2px solid !default;
+@mixin qg-link-decoration {
+  text-decoration-line: underline;
+  text-decoration-thickness: 0.5px;
+  text-decoration-style: solid;
+}
+@mixin qg-link-none-decoration {
+  text-decoration-line: none;
+}
+@mixin qg-link-hover-decoration {
+  text-decoration-line: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-style: solid;
+}
 $text-underline-offset: 5px;

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -46,11 +46,11 @@ $qg-dark-blue2: #005474;
 // ###################################
 
 // Light blue colours
-$qg-pale-blue-darker:	#cde8ec;
-$qg-pale-blue:			#e7f5fe;
+$qg-pale-blue-darker:   #cde8ec;
+$qg-pale-blue:          #e7f5fe;
 
-$qg-pale-blue-dark:		#cecece;
-$qg-pale-blue-light:	#f2f7f9;
+$qg-pale-blue-dark:     #cecece;
+$qg-pale-blue-light:    #f2f7f9;
 
 $qg-blueberry: #759BF3;
 
@@ -81,7 +81,7 @@ $qg-brown: #8a6d3b;
 // Note: Use US spelling for colour
 
 // ## Components
-$qg-icon-color: 		$qg-green;
+$qg-icon-color:         $qg-green;
 
 $brand-success:         #9ebf6d; // #5cb85c;
 $brand-info:            #1E77AA;
@@ -90,8 +90,8 @@ $brand-danger:          #B90824; //#fff;
 
 $state-success-bg:      #f2f7ea;
 $state-success-border:  darken(adjust-hue($state-success-bg, -10), 5%) !default;
-$state-info-bg:      	#eff5f6;
-$state-info-border:  	darken(adjust-hue($state-success-bg, -10), 5%) !default;
+$state-info-bg:         #eff5f6;
+$state-info-border:     darken(adjust-hue($state-success-bg, -10), 5%) !default;
 $state-warning-bg:      #ffedde;
 $state-warning-border:  darken(adjust-hue($state-success-bg, -10), 5%) !default;
 $state-danger-bg:       #B90824;
@@ -247,7 +247,7 @@ $qg-global-prominent: $qg-light-green;
 // ## Dark grey
 $qg-global-dark-grey-active: #373737;
 $qg-global-dark-grey-dark-active: #303030;
-$qg-global-primary-accesible-grey: #767676; // Alternative of $qg-pagination-border as it's not accesible on white background
+$qg-global-primary-accessible-grey: #767676; // Alternative of $qg-pagination-border as it's not accessible on white background
 $qg-light-gray-dark: #efefef;
 
 // ## Red

--- a/src/assets/_project/_blocks/scss-general/bootstrap/_variables.scss
+++ b/src/assets/_project/_blocks/scss-general/bootstrap/_variables.scss
@@ -33,10 +33,12 @@ $text-color:            #000;
 
 //** Global textual link color.
 $link-color:            $qg-blue-dark;
-//** Link hover color set via `darken()` function.
-$link-hover-color:      darken($link-color, 15%) !default;
-//** Link hover decoration.
-$link-hover-decoration: underline !default;
+@mixin link-hover {
+  //** Link hover color set via `darken()` function.
+  color: darken($link-color, 15%);
+  text-decoration-line: underline;
+  text-decoration-color: default;
+}
 
 $grid-gutter-width:         $qg-spacing; // 30px !default;, SWE = 50px;
 $qg-grid-gutter-width-small: $qg-spacing-xs; // Custom for responsive gutter widths


### PR DESCRIPTION
Safari on iOS does not fully support the combined 'text-decoration' declaration, so for greater compatibility, it's best to split it into individual declarations, 'text-decoration-line', 'text-decoration-style', etc.

SASS mixins help to keep this DRY.