### PR TITLE
QOL-9431 Link styling fixes

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -158,3 +158,10 @@
 }
 
 //-------------------------------------------------
+
+// Apply default styling to all links that don't have a button class
+@mixin qg-non-button-link-styles__default {
+  a:not(.qg-btn):not(.btn):not(.button){
+    @include qg-link-styles__default
+  }
+}

--- a/src/assets/_project/_blocks/layout/_pagemodels/_aggregation.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_aggregation.scss
@@ -13,6 +13,7 @@
     h2 {
       font-size: 1.56rem;
     }
+    @include qg-non-button-link-styles__default;
     background: $qg-grey-light;
     padding-bottom: 3rem;
     > .row {

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -18,7 +18,9 @@
       float: left;
     }
     a {
-      text-decoration-line: none !important;
+      &:not(:hover){
+        text-decoration-line: none !important;
+      }
       &:hover {
         img {
           border: 1px solid #06c;

--- a/src/assets/_project/_blocks/layout/asides/_asides.scss
+++ b/src/assets/_project/_blocks/layout/asides/_asides.scss
@@ -11,9 +11,6 @@
 
     margin: 0;
     background-color: #f2f7f9;
-    a {
-      @include qg-link-styles__default;
-    }
     &:last-child{
       border-bottom: none;
     }
@@ -117,4 +114,5 @@
     width: 100%;
     height: auto;
   }
+  @include qg-non-button-link-styles__default;
 }

--- a/src/assets/_project/_blocks/layout/content/_content.scss
+++ b/src/assets/_project/_blocks/layout/content/_content.scss
@@ -7,9 +7,7 @@
       display: block;
     }
   }
-  a:not(.qg-btn):not(.btn):not(.button){
-    @include qg-link-styles__default
-  }
+  @include qg-non-button-link-styles__default;
   .print-content-link{
     @include qg-link-styles__no-underline-default
   }


### PR DESCRIPTION
- Apply link styling to more page blocks (homepage has unusual structure).
- Restrict an index style rule so it doesn't prohibit hovered links from being underlined.