### PR TITLE
[QOL-9431] split 'text-decoration' combined styles into individual declarations

### DIFF
--- a/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
+++ b/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
@@ -22,7 +22,7 @@
         padding: 1rem;
         .title {
           color: $qg-blue-dark;
-          text-decoration: underline;
+          text-decoration-line: underline;
           font-weight: bold;
           padding-right: 1.8rem;
         }
@@ -107,11 +107,11 @@
   }
   .expand, .collapse, label[for="expand"], label[for="collapse"] {
     &:hover, &.hover {
-      text-decoration: underline !important;
+      text-decoration-line: underline !important;
     }
   }
   .ht{
-    text-decoration: underline;
+    text-decoration-line: underline;
   }
   article {
     position: relative;
@@ -131,7 +131,7 @@
       .title{
         display: block;
         &:hover {
-          text-decoration: underline;
+          text-decoration-line: underline;
         }
       }
       label {
@@ -199,7 +199,7 @@
       -webkit-transform: rotate(-135deg);
     }
     &[type=checkbox]:checked + .acc-heading .title{
-      text-decoration: underline;
+      text-decoration-line: underline;
     }
     &.expand:checked ~ article {
       .collapsing-section {
@@ -236,7 +236,7 @@
   .qg-accordion .acc-heading:focus, .qg-accordion .acc-heading.focus {
     outline: 2px solid $qg-blue;
   }
-  .qg-accordion .expand:focus, .qg-accordion .expand:active, .qg-accordion .collapse:focus, .qg-accordion .collapse:active, 
+  .qg-accordion .expand:focus, .qg-accordion .expand:active, .qg-accordion .collapse:focus, .qg-accordion .collapse:active,
   .qg-accordion .expand.focus, .qg-accordion .expand.active, .qg-accordion .collapse.focus, .qg-accordion .collapse.active {
     outline: 2px solid $qg-blue !important;
     outline-offset: -2px;

--- a/src/assets/_project/_blocks/components/banners/_qg-promotional-banner.scss
+++ b/src/assets/_project/_blocks/components/banners/_qg-promotional-banner.scss
@@ -41,7 +41,7 @@
 
   .qg-promotional-banner__popular-apps .qg-btn {
     &:hover, &:visited, &:active {
-      text-decoration: underline !important;
+      text-decoration-line: underline !important;
     }
   }
   .wrapper {

--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -14,7 +14,7 @@
   }
 
   &:hover, &:focus, &.hover, &.focus {
-    text-decoration: underline;
+    text-decoration-line: underline;
     color: #fff;
     background-color: $qg-global-primary-dark-grey;
   }
@@ -40,7 +40,7 @@
 
   &:hover, &:focus, &.hover, &.focus {
     color: $qg-global-primary-dark-grey;
-    text-decoration: underline;
+    text-decoration-line: underline;
   }
 
   &:focus, &.focus {
@@ -61,7 +61,7 @@
 
   &:hover, &:focus, &.hover, &.focus {
     color: #fff;
-    text-decoration: underline;
+    text-decoration-line: underline;
   }
 
   &:focus, &.focus {
@@ -112,7 +112,7 @@
     &:hover:not(:disabled), &:active:not(:disabled), &:focus:not(:disabled), &.hover:not(:disabled), &.active:not(:disabled), &.focus:not(:disabled) {
       border:3px solid $qg-outline-dark-hover;
       color: $qg-outline-dark-hover !important;
-      text-decoration: underline;
+      text-decoration-line: underline;
     }
   }
   &.btn-outline-light{
@@ -120,7 +120,7 @@
     background-color: transparent !important;
     border:3px solid #ffffff;
     &:hover, &:active, &:focus, &.hover, &.active, &.focus {
-      text-decoration: underline;
+      text-decoration-line: underline;
     }
   }
   &.btn-link.light{

--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -366,7 +366,7 @@
   //error alert
   .alert-danger {
     li {
-      text-decoration: underline;
+      text-decoration-line: underline;
       span {
         color: $SecondaryColor;
       }
@@ -514,7 +514,7 @@
       margin-top: -1px;
       color: #13578b;
       font-weight: 700;
-      text-decoration: underline;
+      text-decoration-line: underline;
       .card-title {
         color: #13578b !important;
         padding-right: 28px;
@@ -560,7 +560,7 @@
           border-radius: 0 !important;
           margin: 0;
           margin-right: -1px;
-          text-decoration: underline !important;
+          text-decoration-line: underline !important;
       }
       .page-item:not(.active):hover .page-link {
           text-decoration: none !important;

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -80,19 +80,6 @@
   }
 }
 
-@mixin qg-link-styles__no-underline-black {
-  @include qg-global-link-styles {
-    color: $qg-global-primary-darker-grey;
-    &:link {
-      @include qg-link-none-decoration;
-    }
-    &:hover,
-    &.hover {
-      @include qg-link-hover-decoration;
-    }
-  }
-}
-
 // 2. color theme black with underline
 @mixin qg-link-styles__theme-black {
   @include qg-global-link-styles {

--- a/src/assets/_project/_blocks/components/misc/_qg-images.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-images.scss
@@ -80,7 +80,7 @@
       padding-top: 0.25em;
       margin-top: -0.25em;
       display: inline-block;
-      text-decoration: underline;
+      text-decoration-line: underline;
     }
     @media print {
       word-break: break-all;

--- a/src/assets/_project/_blocks/components/quick-exit/_qg-quick-exit.scss
+++ b/src/assets/_project/_blocks/components/quick-exit/_qg-quick-exit.scss
@@ -58,7 +58,7 @@
         }
         .qg-quick-exit__label {
           font-weight: 500;
-          text-decoration: underline
+          text-decoration-line: underline
         }
         .qg-quick-exit__list {
           margin: 0;
@@ -125,7 +125,7 @@
               margin-right: 8px
             }
             .qg-quick-exit__tip-title {
-              text-decoration: underline
+              text-decoration-line: underline
             }
           }
           .qg-quick-exit__actions {

--- a/src/assets/_project/_blocks/components/site-search/qg-site-search.scss
+++ b/src/assets/_project/_blocks/components/site-search/qg-site-search.scss
@@ -14,7 +14,7 @@
         color: #000 !important;
         text-decoration: none !important;
         &:hover {
-          text-decoration: underline !important;
+          text-decoration-line: underline !important;
         }
       }
       .qg-search__icon {
@@ -27,7 +27,7 @@
           text-decoration: none !important;
           &:hover {
             color: #000 !important;
-            text-decoration: underline;
+            text-decoration-line: underline;
           }
         }
       }
@@ -71,7 +71,7 @@
       border: 2px solid #00698f !important;
       &:hover, &:active, &:focus, &:visited {
         color: #00698f !important;
-        text-decoration: underline !important;
+        text-decoration-line: underline !important;
         font-size: 0.9em;
         padding: 0.7em;
         border: 2px solid #00698f !important;

--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -258,7 +258,7 @@ table.dataTable {
 .paginate_enabled_previous:hover,
 .paginate_disabled_next:hover,
 .paginate_enabled_next:hover {
-  text-decoration: underline;
+  text-decoration-line: underline;
 }
 .paginate_disabled_previous:active,
 .paginate_enabled_previous:active,

--- a/src/assets/_project/_blocks/layout/_print.scss
+++ b/src/assets/_project/_blocks/layout/_print.scss
@@ -18,7 +18,7 @@
 
   a,
   a:visited {
-    text-decoration: underline;
+    text-decoration-line: underline;
   }
 
   a[href]:after {

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -41,7 +41,7 @@
   }
   a {
     color: #fff;
-    text-decoration: underline;
+    text-decoration-line: underline;
     &:hover, &:active, &:focus, &:visited{
       color: #000;
       text-decoration: none;

--- a/src/assets/_project/_blocks/layout/content/_location-setter.scss
+++ b/src/assets/_project/_blocks/layout/content/_location-setter.scss
@@ -149,7 +149,7 @@
         display: block;
         margin-top: 30px;
         padding: 0;
-        text-decoration: underline;
+        text-decoration-line: underline;
 
         &:hover, &:focus {
             color: $qg-global-primary-dark-grey;

--- a/src/assets/_project/_blocks/layout/content/content-types/_cut-in-images.scss
+++ b/src/assets/_project/_blocks/layout/content/content-types/_cut-in-images.scss
@@ -13,7 +13,7 @@
   .qg-cut-in-alt__anchor:hover{
     cursor: pointer;
     .qg-cut-in__large-image a:not(.print-content-link) {
-      text-decoration: underline !important;
+      text-decoration-line: underline !important;
     }
     .qg-cut-in__img-container{
       outline: 1px solid #0066CC;
@@ -97,7 +97,7 @@
     }
     a:not(.print-content-link):hover {
       .qg-cut-in-alt__label {
-        text-decoration: underline;
+        text-decoration-line: underline;
         background: #F5F5F5;
       }
     }

--- a/src/assets/_project/_blocks/layout/content/content-types/_promotions.scss
+++ b/src/assets/_project/_blocks/layout/content/content-types/_promotions.scss
@@ -57,6 +57,6 @@
 
 .qg-promotional-banner__popular-apps .qg-btn {
   &:hover, &:visited, &:active {
-    text-decoration: underline !important;
+    text-decoration-line: underline !important;
   }
 }

--- a/src/assets/_project/_blocks/layout/footer/_footer-feedback.scss
+++ b/src/assets/_project/_blocks/layout/footer/_footer-feedback.scss
@@ -41,7 +41,7 @@
       @include rem(font-size, 14px);
       margin-bottom: 0;
       a {
-        text-decoration: underline;
+        text-decoration-line: underline;
         &:hover, &:focus {
           opacity: 0.7;
         }
@@ -88,7 +88,7 @@
       margin-bottom: 0;
 
       a {
-        text-decoration: underline;
+        text-decoration-line: underline;
         color: #13578b;
         &:hover, &:focus {
           opacity: 0.7;
@@ -123,7 +123,7 @@
       margin: 15px 0;
 
       a {
-        text-decoration: underline;
+        text-decoration-line: underline;
 
         &:hover, &:focus {
           opacity: 0.7;
@@ -140,7 +140,7 @@
     font-weight: normal;
     padding: 0;
     margin-top: 10px;
-    text-decoration: underline;
+    text-decoration-line: underline;
   }
 }
 
@@ -192,7 +192,7 @@
 
     &:hover,&:focus{
       .qg-feedback-toggle__text {
-        text-decoration: underline;
+        text-decoration-line: underline;
       }
     }
 
@@ -265,7 +265,7 @@
       margin-bottom: 0;
 
       a {
-        text-decoration: underline;
+        text-decoration-line: underline;
 
         &:hover, &:focus {
           opacity: 0.7;
@@ -323,7 +323,7 @@
       margin-bottom: 0;
 
       a {
-        text-decoration: underline;
+        text-decoration-line: underline;
 
         &:hover, &:focus {
           opacity: 0.7;
@@ -411,7 +411,7 @@
       margin: 15px 0;
 
       a {
-        text-decoration: underline;
+        text-decoration-line: underline;
 
         &:hover, &:focus {
           opacity: 0.7;
@@ -428,6 +428,6 @@
     font-weight: normal;
     padding: 0;
     margin-top: 10px;
-    text-decoration: underline;
+    text-decoration-line: underline;
   }
 }

--- a/src/assets/_project/_blocks/layout/footer/_service-centre.scss
+++ b/src/assets/_project/_blocks/layout/footer/_service-centre.scss
@@ -31,7 +31,7 @@
 
         &:hover,&:focus {
             .qg-service-centre-set-location__text {
-                text-decoration: underline;
+                text-decoration-line: underline;
             }
         }
     }
@@ -41,7 +41,7 @@
         display: block;
         color: #fff;
         margin: 20px 0;
-        text-decoration: underline;
+        text-decoration-line: underline;
         transition: opacity .1s linear;
 
         &:hover, &:focus {
@@ -76,7 +76,7 @@
             &:nth-child(2):before {
                 content: "\f14e";
             }
-        } 
+        }
     }
 
     .qg-location-setter {

--- a/src/assets/_project/_blocks/layout/footer/_site-footer.scss
+++ b/src/assets/_project/_blocks/layout/footer/_site-footer.scss
@@ -27,11 +27,11 @@
 
         a {
             color: #fff;
-            text-decoration: none;
+            text-decoration-line: none;
             transition: opacity .1s linear;
 
             &:hover, &:focus {
-                text-decoration: underline;
+                text-decoration-line: underline;
                 color: $qg-global-primary-hover-grey;
             }
         }

--- a/src/assets/_project/_blocks/layout/header/_header-location.scss
+++ b/src/assets/_project/_blocks/layout/header/_header-location.scss
@@ -4,7 +4,7 @@
     position: relative;
     .location-name {
         pointer-events: none;
-        text-decoration: underline;
+        text-decoration-line: underline;
     }
     .fa-map-marker {
         color: #fff;

--- a/src/assets/_project/_blocks/layout/header/_portal-links.scss
+++ b/src/assets/_project/_blocks/layout/header/_portal-links.scss
@@ -74,10 +74,12 @@
 
     &.qg-dropdown-all {
       @include qg-link-styles__theme-white;
-      text-decoration: underline 0.5px solid rgba(255, 255, 255, 0.73);
+      text-decoration-thickness: 0.5px;
+      text-decoration-color: rgba(255, 255, 255, 0.73);
 
       &:hover {
-        text-decoration: underline 2px solid #fff;
+        text-decoration-thickness: 2px;
+        text-decoration-color: #fff;
       }
 
       padding-left: 0;
@@ -155,7 +157,7 @@
       @include css-chevron-inline-down(6px, #fff, 20px);
       &:hover, &:focus,
       &[aria-expanded="true"] {
-        text-decoration: underline;
+        text-decoration-line: underline;
       }
       &:focus {
         outline-offset: -3px;

--- a/src/assets/_project/_blocks/layout/header/_site-nav.scss
+++ b/src/assets/_project/_blocks/layout/header/_site-nav.scss
@@ -2,249 +2,249 @@
 // Site navigation
 
 #qg-site-nav {
-	padding-top: 27px;
-	padding-bottom: 10px;
-	.nav {
-		margin: 0;
-		padding: 0;
-		list-style: none;
-	}
-	.nav-link {
-		display: block;
-		padding: 5px 13px;
+    padding-top: 27px;
+    padding-bottom: 10px;
+    .nav {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+    }
+    .nav-link {
+        display: block;
+        padding: 5px 13px;
     @include qg-link-styles__no-underline-white;
-	}
-	@media print {
-		display: none !important;
-	}
+    }
+    @media print {
+        display: none !important;
+    }
 }
 
 
 #qg-site-nav {
-	padding-left: 0;
-	padding-right: 0;
-	background-color: transparent;
-	.nav-item {
-		display: inline-block;
-	}
-	.nav-link {
-		display: inline-block;
-		background-color: transparent;
-		border: 0;
-		border-radius: 4px 4px 0 0;
-		padding: 16px 16px 5px;
-	}
-	.dropdown.mega-dropdown {
-		position: static;
-	}
-	.dropdown-toggle:after {
-		@include rem(border-width, 5px);
-		@include rem(margin-left, 9px);
-		vertical-align: middle;
-	}
-	.dropdown-menu.mega-menu {
-		background-color: $qg-global-primary-light-grey;
-		border: 0;
-		border-radius: 0px 4px 4px 4px;
-		box-shadow: 0 4px 6px 0 rgba(32, 33, 36, 0.47);
-		display: block;
-		max-width: 1010px;
-		padding: 25px 30px;
-		visibility: hidden;
-		width: 100%;
-		z-index: 0;
-		&.show {
-			visibility: visible;
-		}
-		ul {
-			column-count: 3;
-			column-gap: 33px;
-			list-style: none;
-			margin: 0;
-			padding: 0;
-			li {
-				@include rem(line-height, 23px);
-				padding: 14px 10px 13px 25px;
-				display: inline-block;
-				position: relative;
-				width: 100%;
+    padding-left: 0;
+    padding-right: 0;
+    background-color: transparent;
+    .nav-item {
+        display: inline-block;
+    }
+    .nav-link {
+        display: inline-block;
+        background-color: transparent;
+        border: 0;
+        border-radius: 4px 4px 0 0;
+        padding: 16px 16px 5px;
+    }
+    .dropdown.mega-dropdown {
+        position: static;
+    }
+    .dropdown-toggle:after {
+        @include rem(border-width, 5px);
+        @include rem(margin-left, 9px);
+        vertical-align: middle;
+    }
+    .dropdown-menu.mega-menu {
+        background-color: $qg-global-primary-light-grey;
+        border: 0;
+        border-radius: 0px 4px 4px 4px;
+        box-shadow: 0 4px 6px 0 rgba(32, 33, 36, 0.47);
+        display: block;
+        max-width: 1010px;
+        padding: 25px 30px;
+        visibility: hidden;
+        width: 100%;
+        z-index: 0;
+        &.show {
+            visibility: visible;
+        }
+        ul {
+            column-count: 3;
+            column-gap: 33px;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            li {
+                @include rem(line-height, 23px);
+                padding: 14px 10px 13px 25px;
+                display: inline-block;
+                position: relative;
+                width: 100%;
         a {
           @include qg-link-styles__no-underline-default
         }
-				&:before {
-					@include rem(font-size, 12px);
-					content: "\f054";
-					font-family: "FontAwesome";
-					position: absolute;
-					left: 3px;
-					top: 17px;
-				}
-			}
-		}
-	}
-	.show {
-		.nav-link {
-			@include qg-link-styles__no-underline-black;
-			background-color: $qg-global-primary-light-grey !important;
-			position: relative;
-			z-index: 1;
-			&:before {
-				background-color: $qg-global-primary-light-grey !important;
-				bottom: -2px;
-				content: '';
-				height: 2px;
-				left: 0;
-				position: absolute;
-				width: 100%;
-			}
-			&:focus {
-				outline: none;
-			}
-		}
-	}
+                &:before {
+                    @include rem(font-size, 12px);
+                    content: "\f054";
+                    font-family: "FontAwesome";
+                    position: absolute;
+                    left: 3px;
+                    top: 17px;
+                }
+            }
+        }
+    }
+    .show {
+        .nav-link {
+            @include qg-link-styles__no-underline-black;
+            background-color: $qg-global-primary-light-grey !important;
+            position: relative;
+            z-index: 1;
+            &:before {
+                background-color: $qg-global-primary-light-grey !important;
+                bottom: -2px;
+                content: '';
+                height: 2px;
+                left: 0;
+                position: absolute;
+                width: 100%;
+            }
+            &:focus {
+                outline: none;
+            }
+        }
+    }
 }
 
 @include media-breakpoint-down(sm) {
-  .nav-link {
-    @include qg-link-styles__no-underline-black;
-    &:hover {
-      text-decoration: underline 2px solid $qg-global-primary-darker-grey !important;
+    .nav-link {
+        @include qg-link-styles__no-underline-black;
+        &:hover {
+            text-decoration-color: $qg-global-primary-darker-grey !important;
+        }
     }
-  }
-	#qg-site-nav .show .nav-link {
-		text-decoration: none;
-	}
-	.qg-search-form, #qg-site-nav, .qg-portal-links {
-		padding: 0;
-	}
-	#qg-site-nav {
-		width: 100%;
-		.nav {
-			background-color: $qg-global-primary-light-grey;
-			border-radius: 4px;
-			overflow: hidden;
-			margin: 15px 25px;
-		}
-		.nav-item {
-			position: relative;
-			width: 100%;
-			&:before {
-				content: "";
-				background-color: rgba(0,0,0,0.1);
-				position: absolute;
-				height: 1px;
-				width: 100%;
-				bottom: 0;
-			}
-		}
-		.dropdown.mega-dropdown.show {
-			.dropdown-toggle:after {
-				transform: rotate(135deg);
-			}
-		}
-		.nav-link{
+    #qg-site-nav .show .nav-link {
+        text-decoration: none;
+    }
+    .qg-search-form, #qg-site-nav, .qg-portal-links {
+        padding: 0;
+    }
+    #qg-site-nav {
+        width: 100%;
+        .nav {
+            background-color: $qg-global-primary-light-grey;
+            border-radius: 4px;
+            overflow: hidden;
+            margin: 15px 25px;
+        }
+        .nav-item {
+            position: relative;
+            width: 100%;
+            &:before {
+                content: "";
+                background-color: rgba(0,0,0,0.1);
+                position: absolute;
+                height: 1px;
+                width: 100%;
+                bottom: 0;
+            }
+        }
+        .dropdown.mega-dropdown.show {
+            .dropdown-toggle:after {
+                transform: rotate(135deg);
+            }
+        }
+        .nav-link{
       //@include qg-link-styles__no-underline-black;
-			color: $qg-global-primary-darker-grey;
-			padding: 12px 13px 11px;
-			width: 100%;
-		}
-	}
+            color: $qg-global-primary-darker-grey;
+            padding: 12px 13px 11px;
+            width: 100%;
+        }
+    }
 }
 
 @include media-breakpoint-down(xs) {
-	#qg-site-nav {
-		.nav {
-			margin: 15px 10px;
-		}
-	}
+    #qg-site-nav {
+        .nav {
+            margin: 15px 10px;
+        }
+    }
 }
 
 @include media-breakpoint-down(sm) {
-	#qg-site-nav {
-		.nav {
-			display: block;
-		}
-		.dropdown.mega-dropdown {
-			position: relative;
+    #qg-site-nav {
+        .nav {
+            display: block;
+        }
+        .dropdown.mega-dropdown {
+            position: relative;
 
-			.btn.btn-global-primary {
-				width: 100%;
-				text-align: left;
-				padding: 12px 13px;
-				border-radius: 0 0 0 0;
-				border: 0;
-				background-color: #fff;
-				font-weight: normal;
+            .btn.btn-global-primary {
+                width: 100%;
+                text-align: left;
+                padding: 12px 13px;
+                border-radius: 0 0 0 0;
+                border: 0;
+                background-color: #fff;
+                font-weight: normal;
 
-				&:focus,&:hover {
-					opacity: 0.7;
-				}
-			}
-		}
-		.dropdown-toggle {
-			text-align: left;
-			&:after {
+                &:focus,&:hover {
+                    opacity: 0.7;
+                }
+            }
+        }
+        .dropdown-toggle {
+            text-align: left;
+            &:after {
        border: none;
       }
       @include css-chevron-inline-down(6px, $qg-global-primary-darker-grey, 20px);
-		}
+        }
 
-		.dropdown-menu.mega-menu {
-			box-shadow: none;
-			position: static!important;
-			transform: initial!important;
-			display: block;
-			overflow: hidden;
-			padding: 0;
-			max-height: 0;
-			transition: max-height 0.3s ease;
-			&.show {
-				max-height: 1000px;
+        .dropdown-menu.mega-menu {
+            box-shadow: none;
+            position: static!important;
+            transform: initial!important;
+            display: block;
+            overflow: hidden;
+            padding: 0;
+            max-height: 0;
+            transition: max-height 0.3s ease;
+            &.show {
+                max-height: 1000px;
 
-				&:before {
-					display: none;
-				}
-			}
-			ul {
+                &:before {
+                    display: none;
+                }
+            }
+            ul {
         margin: 8px;
-				background-color: #fff;
-				column-count: initial;
-				li {
-					border-bottom: 1px solid rgba(0,0,0,0.1);
-					padding: 0;
-					a {
-						display: block;
-						padding: 12px 13px;
-					}
-					&:before {
-						display: none;
-					}
-				}
-			}
-		}
-	}
+                background-color: #fff;
+                column-count: initial;
+                li {
+                    border-bottom: 1px solid rgba(0,0,0,0.1);
+                    padding: 0;
+                    a {
+                        display: block;
+                        padding: 12px 13px;
+                    }
+                    &:before {
+                        display: none;
+                    }
+                }
+            }
+        }
+    }
 }
 
 // Display search form and site nav at full screen
 
 @include media-breakpoint-up(md) {
-	#qg-site-nav .dropdown-menu.mega-menu {
-		display: block;
-		opacity: 0;
-		top: -1px;
-		transition: none;
-		visibility: hidden;
-		&.show {
-			opacity: 1;
-			transition: opacity .3s ease;
-		}
-	}
-	#qg-site-nav .nav-item {
-		max-height: 45px;
-	}
-	.qg-search-form, .qg-navigation {
-		&.collapse {
-			display: block;
-		}
-	}
+    #qg-site-nav .dropdown-menu.mega-menu {
+        display: block;
+        opacity: 0;
+        top: -1px;
+        transition: none;
+        visibility: hidden;
+        &.show {
+            opacity: 1;
+            transition: opacity .3s ease;
+        }
+    }
+    #qg-site-nav .nav-item {
+        max-height: 45px;
+    }
+    .qg-search-form, .qg-navigation {
+        &.collapse {
+            display: block;
+        }
+    }
 }

--- a/src/assets/_project/_blocks/layout/header/_site-search.scss
+++ b/src/assets/_project/_blocks/layout/header/_site-search.scss
@@ -64,9 +64,9 @@
           padding-bottom: 20px;
           a:not(.btn) {
             color: #fff;
-            text-decoration:underline;
+            text-decoration-line:underline;
             &:hover {
-              text-decoration:none;
+              text-decoration-line:none;
             }
           }
         }
@@ -94,7 +94,7 @@
           display: block;
           margin-top: 20px;
           transition: opacity .1s linear;
-          text-decoration: underline;
+          text-decoration-line: underline;
 
           &:hover, &:focus {
             opacity: 0.7;
@@ -155,7 +155,7 @@
             width: 100%;
 
             &:hover,&:focus {
-              text-decoration: underline;
+              text-decoration-line: underline;
             }
           }
         }

--- a/src/assets/_project/_blocks/layout/header/_site-utilities.scss
+++ b/src/assets/_project/_blocks/layout/header/_site-utilities.scss
@@ -4,11 +4,11 @@
 
   a, a:link, a:hover, a:focus {
     color: $qg-blue5;
-    text-decoration: none;
+    text-decoration-line: none;
   }
   @include breakpoint(md) {
     a:hover {
-      text-decoration: underline;
+      text-decoration-line: underline;
     }
   }
 

--- a/src/assets/_project/_blocks/layout/section-nav/_section-nav.scss
+++ b/src/assets/_project/_blocks/layout/section-nav/_section-nav.scss
@@ -21,7 +21,7 @@
       color: $qg-dark-grey-darker !important;
       font-size: 1rem;
       &:link, &:hover {
-        text-decoration: none 0.5px solid;
+        text-decoration-line: none;
       }
     }
   }
@@ -53,7 +53,7 @@
         color: #212529;
         font-weight: 700;
         &:link, &:hover {
-          text-decoration: none 0.5px solid;
+          text-decoration-line: none;
         }
       }
     }

--- a/src/assets/_project/_blocks/legacy/forms/_forms.scss
+++ b/src/assets/_project/_blocks/legacy/forms/_forms.scss
@@ -876,7 +876,7 @@ input[type="checkbox"] {
 .data dd a:active,
 .data dd a:hover {
   color: inherit;
-  text-decoration: underline;
+  text-decoration-line: underline;
 }
 
 /* data to copy and paste */

--- a/src/assets/_project/_blocks/legacy/forms/_old_forms.scss
+++ b/src/assets/_project/_blocks/legacy/forms/_old_forms.scss
@@ -787,7 +787,7 @@ input:checked + label {
 .data dd a:active,
 .data dd a:hover {
   color: inherit;
-  text-decoration: underline; }
+  text-decoration-line: underline; }
 
 /* data to copy and paste */
 .copypaste {


### PR DESCRIPTION
Particularly refine underline styles to only use 'text-decoration-line' so it's easier for specific elements to customise other aspects (thickness, color).