### PR TITLE
[QOL-9431] preserve thumbnail image size

### DIFF
--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -77,7 +77,7 @@
 
     img {
       display: block;
-      &:not(.actual-image-size) {
+      &:not(.actual-image-size):not(.qg-card__thumbnail) {
         width: 100%;
         height: auto;
       }


### PR DESCRIPTION
- 100% width is now in a more specific block, which would make it override the thumbnail rule, so we need to specifically exclude thumbnails from it