### PR TITLE
QOLDEV-47 fix global search text colour

### DIFF
--- a/src/assets/_project/_blocks/layout/header/_site-search.scss
+++ b/src/assets/_project/_blocks/layout/header/_site-search.scss
@@ -3,6 +3,10 @@
   padding-top: 20px;
   z-index: 2;
 
+  #qg-search-query {
+    color: $qg-global-primary-darker;
+  }
+
   .qg-search-concierge {
     border-top: solid 1px $qg-pagination-border;
     position: absolute;


### PR DESCRIPTION
- Should be dark grey not pale grey
- This was introduced when 7e2c55aded1dfdce8ad94cc6e77806e9d7de433e deleted src/assets/_project/_blocks/scss-general/_qg-global-theme.scss