### PR TITLE
[QOLDEV-34] set rounded corners for all qg-btn borders

### DIFF
--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -6,7 +6,6 @@
   color: #fff;
   background-color: $qg-global-primary-dark;
   font-weight: bold;
-  border-radius: 4px;
   padding: 9px 24px;
   text-decoration-thickness: 2px;
   text-underline-offset: 5px;
@@ -31,7 +30,6 @@
   color: $qg-global-primary-dark-grey;
   background-color: #fff;
   font-weight: bold;
-  border-radius: 4px;
   overflow: hidden;
   padding: 9px 24px;
   display: table;
@@ -59,7 +57,6 @@
   border: solid 3px #fff;
   display: table;
   font-weight: bold;
-  border-radius: 4px;
   padding: 7px 24px;
   text-decoration-line: none;
   text-decoration-thickness: 2px;
@@ -108,6 +105,7 @@
 .qg-btn {
   @extend .btn;
   @include qg-button-outline-decoration;
+  border-radius: $btn-border-radius-base;
 
   &.btn-outline-dark{
     color: $qg-outline-dark;


### PR DESCRIPTION
- Not just btn-global-primary and btn-global-secondary