### PR TITLE
[QOL-9265] fix link outline behaviour in Firefox to match Chrome

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -25,6 +25,9 @@
         background-color: transparent;
         outline: 3px solid #0096d6;
         outline-offset: 2px;
+        // workaround for Firefox border issue on multiline links,
+        // https://www.drupal.org/project/drupal/issues/3016658
+        display: inline-block;
       }
     }
     @content;


### PR DESCRIPTION
- We want a single border around the whole element, not a separate border around each line.