### PR TITLE
[QOL-9265] apply standard outline styles to logo link

### DIFF
--- a/src/assets/_project/_blocks/layout/header/_coat-of-arms.scss
+++ b/src/assets/_project/_blocks/layout/header/_coat-of-arms.scss
@@ -3,6 +3,10 @@
   padding-top: 20px;
   overflow: hidden;
 
+  a {
+    @include qg-global-link-styles;
+  }
+
   img {
     height: 50px;
     width: 289px;


### PR DESCRIPTION
- Otherwise the outline has problems in Firefox