### PR TITLE
[QOLDEV-45] apply standard styling to alert links

### DIFF
--- a/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
+++ b/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
@@ -15,6 +15,11 @@
     margin-top: 5px;
     font-size: 1.2em;
   }
+  a {
+    @include qg-global-link-styles {
+      @include qg-link-decoration;
+    }
+  }
   & + p{
     margin-top: 1em;
   }


### PR DESCRIPTION
- Link underline should be offset 5px and increase thickness on hover/active/focus.