### PR TITLE
[QOLDEV-71] increase mobile menu margins to accommodate outline on focus

### DIFF
--- a/src/assets/_project/_blocks/layout/header/_portal-links.scss
+++ b/src/assets/_project/_blocks/layout/header/_portal-links.scss
@@ -22,11 +22,13 @@
 
     .nav-link {
       padding: 10px 20px 10px 15px;
+      margin: 5px;
       @include qg-link-styles__no-underline-white;
     }
   }
 
   .qg-portal-links__btn {
+    margin: 5px;
     @include qg-link-styles__no-underline-white;
     background-color: $qg-dark-grey-dark;
     border: none;

--- a/src/assets/_project/_blocks/layout/header/_portal-links.scss
+++ b/src/assets/_project/_blocks/layout/header/_portal-links.scss
@@ -22,13 +22,11 @@
 
     .nav-link {
       padding: 10px 20px 10px 15px;
-      margin: 5px;
       @include qg-link-styles__no-underline-white;
     }
   }
 
   .qg-portal-links__btn {
-    margin: 5px;
     @include qg-link-styles__no-underline-white;
     background-color: $qg-dark-grey-dark;
     border: none;
@@ -142,6 +140,9 @@
       overflow: hidden;
       margin: 0 25px;
       width: 100%;
+      .nav-link {
+        margin: 5px;
+      }
     }
     .nav-item {
       border-bottom: 1px solid #000;
@@ -151,6 +152,7 @@
       }
     }
     .qg-portal-links__btn {
+      margin: 5px;
       text-align: left;
       width: 100%;
       &:after {

--- a/src/assets/_project/_blocks/layout/header/_site-nav.scss
+++ b/src/assets/_project/_blocks/layout/header/_site-nav.scss
@@ -153,6 +153,7 @@
       //@include qg-link-styles__no-underline-black;
             color: $qg-global-primary-darker-grey;
             padding: 12px 13px 11px;
+            margin: 5px;
             width: 100%;
         }
     }


### PR DESCRIPTION
On focus, mobile search menu items gain a 3px thickness outline with a 2px offset, so we need a 5px margin to fit it without the risk of crowding.