### PR TITLE
QOLDEV-34 fix styling for 'button' class links

### DIFF
--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -71,7 +71,7 @@
   }
 }
 
-.qg-btn {
+.qg-btn, .button {
   @extend .btn;
   @include qg-button-outline-decoration;
   border-radius: $btn-border-radius-base;

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -26,7 +26,7 @@
 }
 
 @mixin qg-link-unvisited-color($color: $link-color) {
-  &:not(:visited) {
+  &:not(:visited):not(.btn):not(.qg-btn):not(.button) {
     color: $color;
   }
 }

--- a/src/assets/_project/_blocks/legacy/forms/_forms.scss
+++ b/src/assets/_project/_blocks/legacy/forms/_forms.scss
@@ -948,7 +948,6 @@ input[type=reset] {
 .button:hover,
 #asides .button:visited {
   display: inline-block;
-  color: white;
   text-decoration-line: none;
   white-space: nowrap;
 }

--- a/src/assets/_project/_blocks/legacy/forms/_forms.scss
+++ b/src/assets/_project/_blocks/legacy/forms/_forms.scss
@@ -331,6 +331,8 @@ textarea {
   background: white;
   border: 1px solid #cccccc;
   padding: .5em .7em;
+  // apply margin to accommodate border on active/focus
+  margin: 2px;
   max-width: 100%;
   font-family: "Lato", Helvetica, Arial, sans-serif;
 }
@@ -968,7 +970,6 @@ form button,
 .poll .button,
 .actions input,
 #page-feedback form .actions input[type=submit] {
-  margin: 0;
   line-height: 1.2;
   padding: 1em 2em;
   max-width: none;

--- a/src/stories/components/Buttons/templates/States.html
+++ b/src/stories/components/Buttons/templates/States.html
@@ -74,6 +74,12 @@
 <button type="button" class="qg-btn btn-outline-dark active">btn-outline-dark</button>
 <button type="button" class="qg-btn btn-outline-dark" disabled>btn-outline-dark</button>
 
+<a class="button">button</a>
+<a class="button hover">button</a>
+<a class="button focus">button</a>
+<a class="button active">button</a>
+<a class="button" disabled>button</a>
+
 <div class="dark-background">
 <button type="button" class="qg-btn btn-outline-light">btn-outline-light</button>
 </div>


### PR DESCRIPTION
Apply similar styling to 'qg-btn' class.

This is needed for the TMR "Register a boat" button.