### PR TITLE
QOLDEV-29 Fix mobile button underlines

### DIFF
--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -18,7 +18,7 @@
       float: left;
     }
     a {
-      &:not(:hover){
+      &:not(:hover):not(:active):not(:focus) {
         text-decoration-line: none !important;
       }
       &:hover {

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -108,6 +108,16 @@
   }
 }
 
+// Override default link styling, but don't increase priority
+// of other index-links rules
+#qg-content #qg-primary-content .qg-index-links {
+  @include breakpoint(xs) {
+    h2 a {
+      @include qg-link-styles__theme-white;
+    }
+  }
+}
+
 // Stops problems with bootstrap flowing of elements
 @mixin qg-index-item {
   content: '';


### PR DESCRIPTION
Mobile menu links, in button format, should have a white underline on active/focus.