### PR TITLE
[QOLDEV-227] fix side nav buttons so the whole area is clickable

### DIFF
--- a/src/assets/_project/_blocks/layout/section-nav/_section-nav.scss
+++ b/src/assets/_project/_blocks/layout/section-nav/_section-nav.scss
@@ -46,6 +46,7 @@
         @include qg-link-styles__no-underline-black;
       }
       display: block;
+      width: 100%;
       margin: 0;
       padding: 1em;
       color: $qg-dark-grey;


### PR DESCRIPTION
Links need to have either 'display: block' or 'display: inline-block' to prevent a bug with multi-line outlines. Standard styling therefore applies 'inline-block'. However, when the links were previously 'display: block', this causes the clickable area to shrink. Fixed by setting width to 100%.