### PR TITLE
QOLDEV-62 make checkbox styling consistent

### DIFF
--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -271,6 +271,27 @@
     input[type=radio], input[type=checkbox] {
       top:0;
     }
+    input[type=checkbox] {
+      appearance: none;
+      &:checked::before {
+        clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+      }
+
+      @include qg-button-outline-decoration(grid);
+      border: solid currentColor 0.5px;
+      display: grid;
+      place-content: center;
+      &:checked::before {
+        transform: scale(1);
+      }
+      &::before {
+        content: "";
+        width: 1.2em;
+        height: 1.2em;
+        transform: scale(0);
+        box-shadow: inset 1.2em 1.2em black;
+      }
+    }
   }
   .checkbox, .qg-forms-v2__checkbox,
   .form-radio, .qg-forms-v2__radio {
@@ -291,9 +312,9 @@
     }
     input[type=radio], input[type=checkbox] {
       accent-color: $qg-global-primary-darker-grey;
-      width: 25px;
-      height: 25px;
-      padding-right: 16px;
+      width: 1.5em;
+      height: 1.5em;
+      padding: 0.9em;
       margin-top: 0;
       &:checked + label {
         color: inherit;

--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -272,7 +272,7 @@
       top: 0;
       appearance: none;
       @include qg-button-outline-decoration(grid);
-      border: solid currentColor 0.5px;
+      border: solid $qg-dark-grey 2px;
       display: grid;
       place-content: center;
 

--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -290,6 +290,8 @@
 
     input[type=radio] {
       border-radius: 50%;
+      // compatibility with Firefox pre-88
+      -moz-outline-radius: 50%;
       &::before {
         border-radius: 50%;
       }

--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -269,21 +269,13 @@
       display:flex;
     }
     input[type=radio], input[type=checkbox] {
-      top:0;
-    }
-    input[type=checkbox] {
+      top: 0;
       appearance: none;
-      &:checked::before {
-        clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
-      }
-
       @include qg-button-outline-decoration(grid);
       border: solid currentColor 0.5px;
       display: grid;
       place-content: center;
-      &:checked::before {
-        transform: scale(1);
-      }
+
       &::before {
         content: "";
         width: 1.2em;
@@ -291,6 +283,19 @@
         transform: scale(0);
         box-shadow: inset 1.2em 1.2em black;
       }
+      &:checked::before {
+        transform: scale(1);
+      }
+    }
+
+    input[type=radio] {
+      border-radius: 50%;
+      &::before {
+        border-radius: 50%;
+      }
+    }
+    input[type=checkbox]:checked::before {
+      clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
     }
   }
   .checkbox, .qg-forms-v2__checkbox,

--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -134,17 +134,17 @@
   [type="radio"]:disabled,
   [type="checkbox"]:disabled {
     background: transparent;
-    color: $qg-dark-gray-light;
+    color: $qg-dark-grey-lightest;
     cursor: not-allowed;
     +label, +label:before {
       cursor: not-allowed;
       color: $qg-dark-gray-light !important;
     }
     +label:before {
-      border-color: $qg-dark-gray-light;
+      border-color: $qg-dark-grey-lightest;
     }
     +label svg path.rc-theme__icon {
-      fill: $qg-dark-gray-light;
+      fill: $qg-dark-grey-lightest;
     }
   }
 
@@ -273,6 +273,12 @@
       appearance: none;
       @include qg-button-outline-decoration(grid);
       border: solid $qg-dark-grey 2px;
+      &:disabled {
+        border-color: $qg-dark-grey-lightest;
+        &::before {
+          box-shadow: inset 1.2em 1.2em $qg-dark-grey-lightest;
+        }
+      }
       display: grid;
       place-content: center;
 

--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -295,7 +295,7 @@
       }
     }
     input[type=checkbox]:checked::before {
-      clip-path: polygon(14% 44%, 0 65%, 50% 100%, 100% 16%, 80% 0%, 43% 62%);
+      clip-path: polygon(18% 40%, 2% 56%, 37% 91%, 97% 31%, 81% 15%, 37% 59%);
     }
   }
   .checkbox, .qg-forms-v2__checkbox,

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -337,7 +337,7 @@ $qg-linkedin: #0077b5;
 }
 $text-underline-offset: 5px;
 
-@mixin qg-button-outline-decoration {
+@mixin qg-button-outline-decoration ($display: inline-block) {
   // Surround buttons and links with a blue outline when active/focused
   @include on-active {
     outline-width: 3px;
@@ -346,7 +346,7 @@ $text-underline-offset: 5px;
     outline-offset: 2px;
     // workaround for Firefox border issue on multiline links,
     // https://www.drupal.org/project/drupal/issues/3016658
-    display: inline-block;
+    display: $display;
     @content;
   }
 }

--- a/src/stories/components/Forms/Forms.stories.mdx
+++ b/src/stories/components/Forms/Forms.stories.mdx
@@ -1,13 +1,16 @@
 import { Canvas, Meta, Story } from "@storybook/addon-docs";
 
-import { QgPrimaryContent, QgTwoColNav } from "../../decorators";
+import { QgPrimaryContent, QgTwoColNav, Grid } from "../../decorators";
+import { getDecoratedParameters } from "../../helpers";
 
 import TextInput from "./templates/TextInput.html";
 import Textarea from "./templates/Textarea.html";
 import Checkbox from "./templates/Checkbox.html";
 import CheckboxCustom from "./templates/CheckboxCustom.html";
+import CheckboxStates from "./templates/CheckboxStates.html";
 import Radio from "./templates/Radio.html";
 import RadioCustom from "./templates/RadioCustom.html";
+import RadioStates from "./templates/RadioStates.html";
 import Select from "./templates/Select.html";
 import DatePicker from "./templates/DatePicker.html";
 import Validation from "./templates/Validation.html";
@@ -87,6 +90,14 @@ Requires `#QgPrimaryContent` ancestor.
   </Story>
 </Canvas>
 
+## CheckboxStates
+
+<Canvas withSource="close">
+  <Story name="CheckboxStates" decorators={[Grid(5)]} parameters={getDecoratedParameters(CheckboxStates)}>
+    {() => CheckboxStates}
+  </Story>
+</Canvas>
+
 ## Radio
 
 <Canvas withSource="open">
@@ -118,6 +129,14 @@ Requires `#QgPrimaryContent` ancestor.
     }}
   >
     {() => RadioCustom}
+  </Story>
+</Canvas>
+
+## RadioStates
+
+<Canvas withSource="close">
+  <Story name="RadioStates" decorators={[Grid(5)]} parameters={getDecoratedParameters(RadioStates)}>
+    {() => RadioStates}
   </Story>
 </Canvas>
 

--- a/src/stories/components/Forms/templates/CheckboxStates.html
+++ b/src/stories/components/Forms/templates/CheckboxStates.html
@@ -1,0 +1,56 @@
+<span>default</span>
+<span>hover</span>
+<span>focus</span>
+<span>active</span>
+<span>disabled</span>
+
+<form class="qg-forms-v2"><ol class="qg-forms-v2__checkbox">
+  <li>
+    <input type="checkbox" id="default_checkbox_selected" name="default_checkbox" value="selected" checked></input>
+    <label for="default_checkbox">Selected</label>
+  </li>
+  <li>
+    <input type="checkbox" id="default_checkbox_unselected" name="default_checkbox" value="unselected"></input>
+    <label for="default_checkbox">Unselected</label>
+  </li>
+</ol></form>
+<form class="qg-forms-v2"><ol class="qg-forms-v2__checkbox">
+  <li>
+    <input type="checkbox" id="hover_checkbox_selected" name="hover_checkbox" value="selected" class="hover" checked></input>
+    <label for="hover_checkbox">Selected</label>
+  </li>
+  <li>
+    <input type="checkbox" id="hover_checkbox_unselected" name="hover_checkbox" value="unselected" class="hover"></input>
+    <label for="hover_checkbox">Unselected</label>
+  </li>
+</ol></form>
+<form class="qg-forms-v2"><ol class="qg-forms-v2__checkbox">
+  <li>
+    <input type="checkbox" id="focus_checkbox_selected" name="focus_checkbox" value="selected" class="focus" checked></input>
+    <label for="focus_checkbox">Selected</label>
+  </li>
+  <li>
+    <input type="checkbox" id="focus_checkbox_unselected" name="focus_checkbox" value="unselected" class="focus"></input>
+    <label for="focus_checkbox">Unselected</label>
+  </li>
+</ol></form>
+<form class="qg-forms-v2"><ol class="qg-forms-v2__checkbox">
+  <li>
+    <input type="checkbox" id="active_checkbox_selected" name="active_checkbox" value="selected" class="active" checked></input>
+    <label for="active_checkbox">Selected</label>
+  </li>
+  <li>
+    <input type="checkbox" id="active_checkbox_unselected" name="active_checkbox" value="unselected" class="active"></input>
+    <label for="active_checkbox">Unselected</label>
+  </li>
+</ol></form>
+<form class="qg-forms-v2"><ol class="qg-forms-v2__checkbox">
+  <li>
+    <input type="checkbox" id="disabled_checkbox_selected" name="disabled_checkbox" value="selected" checked disabled></input>
+    <label for="disabled_checkbox" disabled>Selected</label>
+  </li>
+  <li>
+    <input type="checkbox" id="disabled_checkbox_unselected" name="disabled_checkbox" value="unselected" disabled></input>
+    <label for="disabled_checkbox" disabled>Unselected</label>
+  </li>
+</ol></form>

--- a/src/stories/components/Forms/templates/RadioStates.html
+++ b/src/stories/components/Forms/templates/RadioStates.html
@@ -1,0 +1,56 @@
+<span>default</span>
+<span>hover</span>
+<span>focus</span>
+<span>active</span>
+<span>disabled</span>
+
+<form class="qg-forms-v2"><ol class="qg-forms-v2__radio">
+  <li>
+    <input type="radio" id="default_radio_selected" name="default_radio" value="selected" checked></input>
+    <label for="default_radio">Selected</label>
+  </li>
+  <li>
+    <input type="radio" id="default_radio_unselected" name="default_radio" value="unselected"></input>
+    <label for="default_radio">Unselected</label>
+  </li>
+</ol></form>
+<form class="qg-forms-v2"><ol class="qg-forms-v2__radio">
+  <li>
+    <input type="radio" id="hover_radio_selected" name="hover_radio" value="selected" class="hover" checked></input>
+    <label for="hover_radio">Selected</label>
+  </li>
+  <li>
+    <input type="radio" id="hover_radio_unselected" name="hover_radio" value="unselected" class="hover"></input>
+    <label for="hover_radio">Unselected</label>
+  </li>
+</ol></form>
+<form class="qg-forms-v2"><ol class="qg-forms-v2__radio">
+  <li>
+    <input type="radio" id="focus_radio_selected" name="focus_radio" value="selected" class="focus" checked></input>
+    <label for="focus_radio">Selected</label>
+  </li>
+  <li>
+    <input type="radio" id="focus_radio_unselected" name="focus_radio" value="unselected" class="focus"></input>
+    <label for="focus_radio">Unselected</label>
+  </li>
+</ol></form>
+<form class="qg-forms-v2"><ol class="qg-forms-v2__radio">
+  <li>
+    <input type="radio" id="active_radio_selected" name="active_radio" value="selected" class="active" checked></input>
+    <label for="active_radio">Selected</label>
+  </li>
+  <li>
+    <input type="radio" id="active_radio_unselected" name="active_radio" value="unselected" class="active"></input>
+    <label for="active_radio">Unselected</label>
+  </li>
+</ol></form>
+<form class="qg-forms-v2"><ol class="qg-forms-v2__radio">
+  <li>
+    <input type="radio" id="disabled_radio_selected" name="disabled_radio" value="selected" checked disabled></input>
+    <label for="disabled_radio" disabled>Selected</label>
+  </li>
+  <li>
+    <input type="radio" id="disabled_radio_unselected" name="disabled_radio" value="unselected" disabled></input>
+    <label for="disabled_radio" disabled>Unselected</label>
+  </li>
+</ol></form>


### PR DESCRIPTION
Compare to designs on Figma: https://www.figma.com/file/5BrkUy62yKzGbRJnrUcLLM/Form-control-inputs%3A-Radio-and-checkbox?node-id=19%3A1893

- Use black checkmark on a white background regardless of browser defaults.
- Apply blue outline on focus.
