### PR TITLE
QOLDEV-245 fix print guide styling

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -22,7 +22,6 @@
       &:focus-visible,
       &.active,
       &.focus {
-        background-color: transparent;
         outline: 3px solid #0096d6;
         outline-offset: 2px;
         // workaround for Firefox border issue on multiline links,

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -26,7 +26,9 @@
         outline-offset: 2px;
         // workaround for Firefox border issue on multiline links,
         // https://www.drupal.org/project/drupal/issues/3016658
-        display: inline-block;
+        &:not(.pagination a) {
+          display: inline-block;
+        }
       }
     }
     @content;

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -24,11 +24,11 @@
       &.focus {
         outline: 3px solid #0096d6;
         outline-offset: 2px;
-        // workaround for Firefox border issue on multiline links,
-        // https://www.drupal.org/project/drupal/issues/3016658
-        &:not(.pagination a) {
-          display: inline-block;
-        }
+      }
+      // workaround for Firefox border issue on multiline links,
+      // https://www.drupal.org/project/drupal/issues/3016658
+      &:not(.pagination a) {
+        display: inline-block;
       }
     }
     @content;

--- a/src/assets/_project/_blocks/layout/_pagemodels/_guide.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_guide.scss
@@ -36,6 +36,9 @@
 
   }
 
+  .pagination {
+    margin-top: 2em;
+  }
   .next  {
     position: absolute;
     right: 15px;

--- a/src/stories/components/Print/templates/PrintGuide.html
+++ b/src/stories/components/Print/templates/PrintGuide.html
@@ -12,4 +12,8 @@
       ><span class="fa fa-print"></span> Print entire guide</a
     >
   </p>
+  <ul class="pagination">
+    <li class="previous"><a href="https://www.qld.gov.au/environment/plants-animals/wildlife-permits/permit-types/recreational-licence/responsibilities">Previous</a></li>
+    <li class="next"><a href="https://www.qld.gov.au/environment/plants-animals/wildlife-permits/permit-types/recreational-licence/responsibilities">Next</a></li>
+  </ul>
 </section>


### PR DESCRIPTION
- Increase spacing above pagination links
- Don't add 'display: inline-block' to pagination links on focus
- Don't force link backgrounds to be transparent