### PR TITLE
QOLDEV-245 fix Digital Dashboard links

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -27,7 +27,7 @@
       }
       // workaround for Firefox border issue on multiline links,
       // https://www.drupal.org/project/drupal/issues/3016658
-      &:not(.pagination a) {
+      &:not(.pagination a, .graph a) {
         display: inline-block;
       }
     }

--- a/src/assets/_project/_blocks/legacy/forms/_forms.scss
+++ b/src/assets/_project/_blocks/legacy/forms/_forms.scss
@@ -977,7 +977,6 @@ form button,
   max-width: none;
   font-weight: bold;
   font-style: normal;
-  color: #ffffff;
   background: #585E62;
   border: none;
   //border-radius: 0;

--- a/src/assets/_project/_blocks/legacy/forms/_old_forms.scss
+++ b/src/assets/_project/_blocks/legacy/forms/_old_forms.scss
@@ -876,12 +876,12 @@ form button,
   max-width: none;
   font-weight: bold;
   font-style: normal;
-  color: #ffffff;
   background: #585E62;
   border: none;
   border-radius: 0;
   -moz-border-radius: 0;
-  -webkit-border-radius: 0; }
+  -webkit-border-radius: 0;
+}
 
 /* slimmer buttons in asides */
 .aside button,

--- a/src/stories/components/Buttons/templates/Links.html
+++ b/src/stories/components/Buttons/templates/Links.html
@@ -1,15 +1,13 @@
 <p class="actions">
-  <strong>
-    <a class="qg-btn button" href="http://example.com">'qg-btn' link</a>
-  </strong>
+  <a class="qg-btn button" href="http://example.com">'qg-btn' link</a>
+  <a class="btn button" href="http://example.com">'btn' link</a>
+  <a class="button" href="http://example.com">'button' link</a>
 </p>
+
 <p class="actions">
   <strong>
-    <a class="btn button" href="http://example.com">'btn' link</a>
-  </strong>
-</p>
-<p class="actions">
-  <strong>
-    <a class="button" href="http://example.com">'button' link</a>
+    <a class="qg-btn button" href="http://example.com">Strong 'qg-btn' link</a>
+    <a class="btn button" href="http://example.com">Strong 'btn' link</a>
+    <a class="button" href="http://example.com">Strong 'button' link</a>
   </strong>
 </p>


### PR DESCRIPTION
- Don't apply 'inline-block' styling to the Digital Dashboard graph headings since it interferes with existing 'block' styling
- Make 'More Information' links consistently white