### PR TITLE
[QOLSVC-635] restrict 'inline-block' styling to prevent side effects

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -25,11 +25,6 @@
         outline: 3px solid #0096d6;
         outline-offset: 2px;
       }
-      // workaround for Firefox border issue on multiline links,
-      // https://www.drupal.org/project/drupal/issues/3016658
-      &:not(.pagination a, .graph a) {
-        display: inline-block;
-      }
     }
     @content;
   }

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -18,6 +18,9 @@
       float: left;
     }
     a {
+      // workaround for Firefox border issue on multiline links,
+      // https://www.drupal.org/project/drupal/issues/3016658
+      display: inline-block;
       &:not(:hover){
         text-decoration-line: none !important;
       }


### PR DESCRIPTION
- Only apply inline-block to selected elements like index links, not as a default, since it causes disruptions like extra line breaks, overriding expected widths, etc.