### PR TITLE
QOLDEV-260 heading line height fix

### DIFF
--- a/src/assets/_project/_blocks/layout/_typography.scss
+++ b/src/assets/_project/_blocks/layout/_typography.scss
@@ -1,6 +1,12 @@
-h2 {
-  line-height: 1.5em;
+h3, h4 {
+  line-height: 1.4;
 }
+
+h5, h6 {
+  line-height: 1.5;
+}
+
+
 blockquote {
   border: none;
   font-size: 1.6rem;

--- a/src/assets/_project/_blocks/layout/_typography.scss
+++ b/src/assets/_project/_blocks/layout/_typography.scss
@@ -6,7 +6,6 @@ h5, h6 {
   line-height: 1.5;
 }
 
-
 blockquote {
   border: none;
   font-size: 1.6rem;

--- a/src/assets/_project/_blocks/scss-general/bootstrap/_variables.scss
+++ b/src/assets/_project/_blocks/scss-general/bootstrap/_variables.scss
@@ -71,7 +71,7 @@ $h6-font-size:                rem(11px) !default;
 $headings-margin-bottom:      ($spacer * 0.5) !default;
 $headings-font-family:        inherit !default;
 $headings-font-weight:        900 !default;
-$headings-line-height:        1.1 !default;
+$headings-line-height:        1.3 !default;
 $headings-color:              inherit !default;
 
 $display1-size:               6rem !default;


### PR DESCRIPTION
Current heading line-heights are based on the imported Bootstrap (3-ish) styles where default is 1.1 ([unitless](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#values)), except for h2 which has been customised to be 1.5rem.

As a fix to adjust the heading line heights to accommodate new hyperlink styles my pull request proposes to:

- Increase default line-height of headings to 1.3 (this will then apply to h1 and h2)
- Increase line-height of h3 and h4 to 1.4
- Increase line-height of h5 and h6 to 1.5