### PR TITLE
QOLDEV-223 accordion link styling

### DIFF
--- a/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
+++ b/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
@@ -26,12 +26,6 @@
           font-weight: bold;
           padding-right: 1.8rem;
         }
-        &:hover, &.hover {
-          .title{
-            text-decoration-line: none;
-            color: $qg-dark-grey-darker;
-          }
-        }
         .qg-accordion--ga:after {
           content: ' ';
           position: absolute;
@@ -51,9 +45,6 @@
           margin-left: 2.5rem;
           margin-bottom: 0;
         }
-      }
-      .qg-accordion--ga{
-        text-decoration:none !important;
       }
       .qg-accordion--open .qg-accordion--ga:after{
         transform: rotate(0deg);

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -60,6 +60,7 @@
   @include qg-global-link-styles {
     @include qg-link-decoration;
     @include qg-link-visited-decoration;
+    @include qg-underline-on-highlight-decoration;
     &:not(.qg-private-content-link) {
       @include qg-link-unvisited-color;
       text-decoration-color: #457aa3;
@@ -160,7 +161,7 @@
 // Apply default styling to all links that don't have a button class
 @mixin qg-non-button-link-styles__default {
   a:not(.qg-btn):not(.btn):not(.button){
-    @include qg-link-styles__default
+    @include qg-link-styles__default;
   }
 }
 


### PR DESCRIPTION
Update accordion appearance according to new Figma designs

- Accordion links should be blue on hover, not black, with a thicker underline instead of none.