### PR TITLE
QOLDEV-226 update card focus state

### DIFF
--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -271,7 +271,7 @@
     input[type=radio], input[type=checkbox] {
       top: 0;
       appearance: none;
-      @include qg-button-outline-decoration(grid);
+      @include qg-button-outline-decoration;
       border: solid $qg-pagination-border 2px;
       position: static;
       &:disabled {

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -35,6 +35,7 @@
 @mixin qg-link-unvisited-color($color: $link-color) {
   &:not(:visited):not(.btn):not(.qg-btn):not(.button) {
     color: $color;
+    @content;
   }
 }
 
@@ -61,8 +62,9 @@
     @include qg-link-decoration;
     @include qg-link-visited-decoration;
     &:not(.qg-private-content-link) {
-      @include qg-link-unvisited-color;
-      text-decoration-color: #457aa3;
+      @include qg-link-unvisited-color {
+        text-decoration-color: #457aa3;
+      }
     }
   }
 }

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -19,14 +19,7 @@
     // }
     // Don't apply outlines to button links or the Digital Dashboard
     &:not(.btn-link, button a, #ia-format a) {
-      &:active,
-      &:focus,
-      &:focus-visible,
-      &.active,
-      &.focus {
-        outline: 3px solid #0096d6;
-        outline-offset: 2px;
-      }
+      @include qg-button-outline-decoration;
     }
     @content;
   }

--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -4,16 +4,15 @@
 
   &.qg-card__clickable {
     .content {
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+      @include qg-button-outline-decoration;
 
-      &:hover {
-        box-shadow: none;
+      h2 a {
+        @include all-states {
+          outline-style: none !important;
+        }
       }
     }
 
-    .content:focus-within {
-      box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
-    }
   }
 
   .btn-primary {

--- a/src/assets/_project/_blocks/layout/content/_content.scss
+++ b/src/assets/_project/_blocks/layout/content/_content.scss
@@ -7,7 +7,6 @@
       display: block;
     }
   }
-  @include qg-non-button-link-styles__default;
   .print-content-link{
     @include qg-link-styles__no-underline-default
   }
@@ -77,3 +76,5 @@
     clear: both;
   }
 }
+
+@include qg-non-button-link-styles__default;

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -271,7 +271,7 @@ $qg-linkedin: #0077b5;
 
 @mixin on-active() {
   &:active, &.active,
-  &:focus, &.focus, &:focus-visible {
+  &:focus, &.focus, &:focus-visible, &:focus-within {
     &:not(:disabled, .disabled) {
       @content;
     }
@@ -330,16 +330,13 @@ $qg-linkedin: #0077b5;
 
 $text-underline-offset: 5px;
 
-@mixin qg-button-outline-decoration ($display: inline-block) {
+@mixin qg-button-outline-decoration {
   // Surround buttons and links with a blue outline when active/focused
   @include on-active {
     outline-width: 3px;
     outline-style: solid;
     outline-color: $qg-active-outline;
     outline-offset: 2px;
-    // workaround for Firefox border issue on multiline links,
-    // https://www.drupal.org/project/drupal/issues/3016658
-    display: $display;
     @content;
   }
 }


### PR DESCRIPTION
Replace box shadow with a standard outline, as per Figma designs.