### PR TITLE
[QOLDEV-222] fix outline on document download link focus

### DIFF
--- a/src/assets/_project/_blocks/components/misc/_qg-misc.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-misc.scss
@@ -10,7 +10,6 @@
 
 a{
   .meta{
-    display: inline-block;
     text-decoration-line: none;
   }
 }


### PR DESCRIPTION
- Drop 'inline-block' styling so that the file metadata is the same height as the other text on Chrome/Safari, thus keeping the focus outline rectangular. This will have the undesired side effect that the underline will continue under the entire link.