### PR TITLE
QOLDEV-268 Fix digital dashboard focus colour

### DIFF
--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -39,7 +39,7 @@
 
   @include qg-underline-on-highlight-decoration {
     // repeat colour rule with greater priority
-    color: #fff;
+    color: white;
   }
 }
 

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -37,7 +37,7 @@
   color: white;
   text-decoration-color: rgba(255, 255, 255, 0.73);
   @include qg-underline-on-highlight-decoration {
-    text-decoration-color: #fff;
+    text-decoration-color: white;
   }
 }
 

--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -5,14 +5,7 @@
   &.qg-card__clickable {
     .content {
       @include qg-button-outline-decoration;
-
-      h2 a {
-        @include all-states {
-          outline-style: none !important;
-        }
-      }
     }
-
   }
 
   .btn-primary {

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -339,5 +339,9 @@ $text-underline-offset: 5px;
     outline-color: $qg-active-outline;
     outline-offset: 2px;
     @content;
+    * {
+      // don't apply an extra outline to any children
+      outline-style: none !important;
+    }
   }
 }

--- a/src/stories/helpers/getDecoratedParameters.js
+++ b/src/stories/helpers/getDecoratedParameters.js
@@ -1,7 +1,7 @@
-export const getDecoratedParameters = (tempalte) => ({
+export const getDecoratedParameters = (template) => ({
   docs: {
     source: {
-      code: tempalte,
+      code: template,
     },
   },
 });


### PR DESCRIPTION
Update the standard outline mixin to ensure that children of outlined elements will not apply extra outlines.