### PR TITLE
[QOLDEV-245] increase spacing for print guide pagination

### DIFF
--- a/src/assets/_project/_blocks/layout/_pagemodels/_guide.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_guide.scss
@@ -37,7 +37,7 @@
   }
 
   .pagination {
-    margin-top: 2em;
+    margin-top: 3em;
   }
   .next  {
     position: absolute;


### PR DESCRIPTION
- Safari seems to handle the flexbox configuration differently, resulting in the margin-top being too small and crowding the element above, so let's make it bigger.