### PR TITLE
QOLDEV-278 fix double underline in validation error box

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -11,7 +11,9 @@
       .page-link):not(.dfv-cards--type-top-prompt
       a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.print-content-link):not(.qg-aside-button):not(.dfv-back
       a):not(.QSAR-records-search a) {
-    text-underline-offset: $text-underline-offset;
+    &:not(span[role=link] *) {
+      text-underline-offset: $text-underline-offset;
+    }
     // not sure why Asif need to add this, which will have side-effect on customised style added by franchise.
     // &:hover,
     // &.hover {

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -291,7 +291,9 @@ $qg-linkedin: #0077b5;
 @mixin qg-link-underline {
   text-decoration-line: underline;
   text-decoration-style: solid;
-  text-underline-offset: $text-underline-offset;
+  &:not(span[role=link] *) {
+    text-underline-offset: $text-underline-offset;
+  }
 }
 @mixin _qg-link-underline-thicker {
   @include qg-link-underline;

--- a/src/stories/components/Forms/templates/Validation.html
+++ b/src/stories/components/Forms/templates/Validation.html
@@ -1,3 +1,25 @@
+<div class="alert alert-danger" id="error-list-ezf0c7p">
+  <p></p><h2><span class="fa fa-exclamation-triangle"></span> Please check your answers</h2>
+  <p></p>
+  <ul>
+    <li>
+      <span data-component-key="general.comments" ref="errorRef" tabindex="0" role="link">
+        Comments is required
+      </span>
+    </li>
+    <li>
+      <span data-component-key="contact.howWouldYouLikeToBeContacted" ref="errorRef" tabindex="0" role="link">
+        How would you like to be contacted? is required
+      </span>
+    </li>
+    <li>
+      <span data-component-key="contact.privacyAcknowledgement.iHaveReadAndUnderstoodTheAHrefPrivacyStatementA" ref="errorRef" tabindex="0" role="link">
+        I have read and understood the <a href="https://www.qld.gov.au/contact-us/contact-us-online-form-privacy-statement" target="_blank" rel="nofollow noopener" title="Opens in new window">privacy statement<span class="qg-blank-notice sr-only"> (Opens in new window)</span></a> is required
+      </span>
+    </li>
+  </ul>
+</div>
+
 <form class="qg-forms-v2" novalidate="true">
   <ol class="questions">
     <li class="invalid">


### PR DESCRIPTION
Don't apply a different underline offset to links inside form.io spans that will have an underline for the whole text.