### PR TITLE
[QOLDEV-223] fix accordion heading height

### DIFF
--- a/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
+++ b/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
@@ -40,6 +40,9 @@
           z-index: 101;
           transition: transform 0.25s ease-in;
         }
+        .accordion-label {
+          display: inline-block;
+        }
         img + .accordion-label{
           display: block;
           margin-left: 2.5rem;


### PR DESCRIPTION
- Use 'display: inline-block' to stop accordion headings from unnecessarily line-wrapping