### PR TITLE
[DC-33448][QOLCHG-87] fix global search suggestions being clicked

### DIFF
--- a/src/assets/_project/_blocks/components/site-search/qg-site-search.js
+++ b/src/assets/_project/_blocks/components/site-search/qg-site-search.js
@@ -475,7 +475,7 @@ $(function () {
   });
 
   // Binds
-  $('body').on('focusin', '.qg-navigation .nav-link, .qg-service-finder__popular-apps a, .qg-coat-of-arms a, .qg-site-header button', qgSiteSearch.fn.handleFocus);
+  $('body').on('focusin', '.qg-navigation .nav-link, .qg-coat-of-arms a, .qg-site-header button', qgSiteSearch.fn.handleFocus);
   $('body').on('click', qgSiteSearch.fn.handleBodyClick);
   $('body').on('click', '.qg-search-close-concierge', qgSiteSearch.fn.clearInputField);
   $('body').on('click', '.qg-search-concierge-group.suggestions button', qgSiteSearch.fn.searchSuggestionClick);


### PR DESCRIPTION
- Don't collapse the Concierge box too aggressively when components are clicked, since we need to allow clicking on search suggestions