### PR TITLE
[DC-33448][QOLCHG-87] fix global search suggestions

### DIFF
--- a/src/assets/_project/_blocks/components/site-search/qg-site-search.js
+++ b/src/assets/_project/_blocks/components/site-search/qg-site-search.js
@@ -475,7 +475,7 @@ $(function () {
   });
 
   // Binds
-  $('body').on('focusin', '.qg-navigation .nav-link, .qg-coat-of-arms a, .qg-site-header button', qgSiteSearch.fn.handleFocus);
+  $('body').on('focusin', '.qg-navigation .nav-link, .qg-service-finder__popular-apps a, .qg-coat-of-arms a', qgSiteSearch.fn.handleFocus);
   $('body').on('click', qgSiteSearch.fn.handleBodyClick);
   $('body').on('click', '.qg-search-close-concierge', qgSiteSearch.fn.clearInputField);
   $('body').on('click', '.qg-search-concierge-group.suggestions button', qgSiteSearch.fn.searchSuggestionClick);


### PR DESCRIPTION
- We need to drop the binding to all header buttons, since the search suggestions are button elements

Previous pull request unfortunately didn't fix it, but I've now narrowed down exactly which selector caused the problem and why.