### PR TITLE
[QOLDEV-275] fix Digital Dashboard tender links on Chrome

### DIFF
--- a/src/docs/assets/css/ictdashboard.css
+++ b/src/docs/assets/css/ictdashboard.css
@@ -851,7 +851,7 @@ body .qg-projects-search form .questions input.inp {
   padding: 1em 1em 1em 46px; }
 
 #ia-format ul a {
-  display: inline;
+  display: inline-block;
   padding: 0;
   margin: 0;
   text-align: left;


### PR DESCRIPTION
- Use 'display: inline-block' to stop tender links from generating spurious line breaks in Chrome