### PR TITLE
QOLDEV-260 heading line height fix - h2 only

### DIFF
--- a/src/assets/_project/_blocks/layout/_typography.scss
+++ b/src/assets/_project/_blocks/layout/_typography.scss
@@ -1,6 +1,12 @@
-h2 {
-  line-height: 1.5em;
+h3, h4 {
+  line-height: 1.4;
 }
+
+h5, h6 {
+  line-height: 1.5;
+}
+
+
 blockquote {
   border: none;
   font-size: 1.6rem;

--- a/src/assets/_project/_blocks/layout/_typography.scss
+++ b/src/assets/_project/_blocks/layout/_typography.scss
@@ -1,4 +1,4 @@
-h3, h4 {
+h2, h3, h4 {
   line-height: 1.4;
 }
 

--- a/src/assets/_project/_blocks/layout/_typography.scss
+++ b/src/assets/_project/_blocks/layout/_typography.scss
@@ -6,7 +6,6 @@ h5, h6 {
   line-height: 1.5;
 }
 
-
 blockquote {
   border: none;
   font-size: 1.6rem;

--- a/src/assets/_project/_blocks/scss-general/bootstrap/_variables.scss
+++ b/src/assets/_project/_blocks/scss-general/bootstrap/_variables.scss
@@ -71,7 +71,7 @@ $h6-font-size:                rem(11px) !default;
 $headings-margin-bottom:      ($spacer * 0.5) !default;
 $headings-font-family:        inherit !default;
 $headings-font-weight:        900 !default;
-$headings-line-height:        1.1 !default;
+$headings-line-height:        1.3 !default;
 $headings-color:              inherit !default;
 
 $display1-size:               6rem !default;


### PR DESCRIPTION
It was noticed that for any h2 heading links in an aside that the underline weight change on hover was not entirely visible. Increasing h2 line-height to 1.4 addressed the problem.

Edit: Here's a screenshot example of what was happening:
<img width="312" alt="example-h2-linkhover-aside-bug" src="https://user-images.githubusercontent.com/950889/219980411-3720aeff-26ec-48e1-939a-8ec4dfcb0da5.png">
