### PR TITLE
[QOLDEV-223] ensure accordions use thicker underline on hover

### DIFF
--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -304,6 +304,11 @@ $qg-linkedin: #0077b5;
   @include on-hover-or-active {
     @include _qg-link-underline-thicker;
     @content;
+    // ensure spans within links follow their parent
+    span {
+      @include _qg-link-underline-thicker;
+      @content;
+    }
   }
 }
 @mixin qg-link-decoration {

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -305,7 +305,7 @@ $qg-linkedin: #0077b5;
     @include _qg-link-underline-thicker;
     @content;
     // ensure spans within links follow their parent
-    span {
+    span.title {
       @include _qg-link-underline-thicker;
       @content;
     }


### PR DESCRIPTION
- Chrome makes the inner spans inherit from the link automatically, but Firefox does not, so we make it explicit