### PR TITLE
QOLDEV-301 Removing aria-required from search input

### DIFF
--- a/src/assets/_project/_blocks/layout/site-search-form.html
+++ b/src/assets/_project/_blocks/layout/site-search-form.html
@@ -1,7 +1,7 @@
 <form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
     <div class="input-group">
       <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-      <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+      <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
       <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
         <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
           <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/breadcrumb.html
+++ b/src/docs/examples/breadcrumb.html
@@ -237,7 +237,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/cut-in.html
+++ b/src/docs/examples/cut-in.html
@@ -228,7 +228,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/form-new-styles.html
+++ b/src/docs/examples/form-new-styles.html
@@ -200,7 +200,7 @@
       </button><form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/formio.html
+++ b/src/docs/examples/formio.html
@@ -197,7 +197,7 @@
       </button><form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/guide-page.html
+++ b/src/docs/examples/guide-page.html
@@ -192,7 +192,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/index.html
+++ b/src/docs/examples/index.html
@@ -138,7 +138,7 @@
       <form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
         <div class="input-group">
           <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-          <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+          <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
           <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
             <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
               <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/recaptcha2.html
+++ b/src/docs/examples/recaptcha2.html
@@ -245,7 +245,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/search-page.html
+++ b/src/docs/examples/search-page.html
@@ -235,7 +235,7 @@
       <form id="qg-global-search-form" action="https://www.qld.gov.au/search" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">
@@ -439,7 +439,7 @@
         <form action="#" role="search" class="qg-site-search__form qg-site-search__component qg-search-form qg-site-search__multiple-forms" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
           <div class="input-group">
             <label for="qg-search-query-sm" class="qg-visually-hidden">Search Queensland Government</label>
-            <input type="text" name="query" id="qg-search-query-sm"  class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+            <input type="text" name="query" id="qg-search-query-sm"  class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
             <svg class="qg-search__icon d-none d-md-block d-lg-block" width="512px" height="512px" viewBox="0 0 512 512">
               <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
                 <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/section-nav-example.html
+++ b/src/docs/examples/section-nav-example.html
@@ -226,7 +226,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/service-finder.html
+++ b/src/docs/examples/service-finder.html
@@ -341,7 +341,7 @@
       <form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete qg-sf-global" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" accesskey="5" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" accesskey="5" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/stories/components/Header/templates/Search.html
+++ b/src/stories/components/Header/templates/Search.html
@@ -1,7 +1,7 @@
 <form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete qg-site-search__form" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&amp;fmt=json%2B%2B&amp;alpha=0.5&amp;profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&amp;profile=qld&amp;smeta_sfinder_sand=yes" novalidate="true">
     <div class="input-group">
       <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-      <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-required="true" aria-expanded="false">
+      <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false">
       <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
         <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
           <g transform="translate(67.298684, 71.201316)">


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-301
Derived from: https://ssq-qol.atlassian.net/browse/QOLSVC-433

Search inbox should not have aria-required=true as it is not a mandatory field.