### PR TITLE
 QOLDEV-164 Adjusted opacity value of banner blurb background for better contrast with text

### DIFF
--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -51,7 +51,7 @@
   }
   .blurb {
     position: inherit;
-    background: rgba(0, 0, 0, 0.5);
+    background: rgba(0, 0, 0, 0.65);
     color: white;
     margin: 0 15px;
     padding: 1em;


### PR DESCRIPTION
**Internal ticket reference**: [https://ssq-qol.atlassian.net/browse/QOLDEV-164](https://ssq-qol.atlassian.net/browse/QOLDEV-164)

**WCAG 2.1 technique reference**: [https://www.w3.org/WAI/WCAG21/Techniques/general/G18](https://www.w3.org/WAI/WCAG21/Techniques/general/G18)

**Tools** I used for checking contrast of text colour on a background image:
- [Optimal Overlay Finder - Readable Text on a Background Image](https://codepen.io/yaphi1/live/oNbEqGV )
- [A11y accessibility check for text colour on background image](http://www.brandwood.com/a11y/ )

[This article](https://css-tricks.com/nailing-the-perfect-contrast-between-light-text-and-a-background-image/) found that for the common case of white text on a black transparent overlay, you’ll never need an opacity over 0.54 to achieve WCAG AA-level readability.

**Recommendation**: I suggest applying an opacity of 0.65 to good results across (most) images used and to achieve WCAG 2.1 AAA level compliance.