### PR TITLE
Qoldev 321 print button and hover state

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -9,7 +9,7 @@
   // make exception for certain classes, which need to re-visit for better optimization
   &:not(.qg-feature-box .qg-link):not(.qg-index a.qg-index-item):not(.page-item
       .page-link):not(.dfv-cards--type-top-prompt
-      a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.print-content-link):not(.qg-aside-button):not(.dfv-back
+      a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.qg-aside-button):not(.dfv-back
       a):not(.QSAR-records-search a):not(.dfv-content a.qg-links-list__link) {
     &:not(span[role=link] *) {
       text-underline-offset: $text-underline-offset;

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -41,7 +41,7 @@
 }
 
 @mixin _qg-link-none-decoration {
-  text-decoration-line: none;
+  text-decoration-line: none !important;
   @include qg-link-visited-decoration;
 }
 

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -41,7 +41,7 @@
 }
 
 @mixin _qg-link-none-decoration {
-  text-decoration-line: none !important;
+  text-decoration-line: none;
   @include qg-link-visited-decoration;
 }
 

--- a/src/assets/_project/_blocks/layout/section-nav/_section-nav.scss
+++ b/src/assets/_project/_blocks/layout/section-nav/_section-nav.scss
@@ -50,7 +50,7 @@
         color: #212529;
         font-weight: 700;
       }
-      @include on-hover-or-active {
+      @include on-hover {
         background-color: $qg-section-nav-bg-color;
       }
     }

--- a/src/assets/_project/_blocks/layout/section-nav/_section-nav.scss
+++ b/src/assets/_project/_blocks/layout/section-nav/_section-nav.scss
@@ -18,7 +18,7 @@
       display: inline-block;
       color: $qg-dark-grey-darker !important;
       font-size: 1rem;
-      @include on-hover-or-active {
+      @include on-hover {
         background-color: $qg-section-nav-bg-color;
       }
     }

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -303,7 +303,7 @@ $qg-linkedin: #0077b5;
 }
 @mixin qg-underline-on-highlight-decoration {
   // apply a 2px underline on hover/focus/active
-  @include on-hover-or-active {
+  @include on-hover {
     @include _qg-link-underline-thicker;
     @content;
     // ensure spans within links follow their parent


### PR DESCRIPTION
https://oss-uat.clients.squiz.net//health/services/travel/subsidies/ptss-subsidies

Based on https://www.figma.com/file/veO6GlWUx6rVmMeo9vPECS/SWE-UI-kit?node-id=4137-8713 grey background for the side nav items only should occur on hover, and not active.

This completes https://ssq-qol.atlassian.net/browse/QOLDEV-199

Print link was missing the blue outline when focused. It should not be underlined though.
https://ssq-qol.atlassian.net/browse/QOLDEV-321
