### PR TITLE
QOLDEV-314 Updating the outline on main nav items

### DIFF
--- a/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
+++ b/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
@@ -63,7 +63,7 @@
     }
   }
   button {
-    @include qg-button-outline-decoration (0px) {
+    @include qg-button-outline-decoration ($margin: 0px) {
       z-index: 100;
     }
   }

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -54,7 +54,6 @@
     @include qg-link-decoration;
     @include qg-link-visited-decoration;
     @include qg-underline-on-highlight-decoration;
-    //@include qg-button-outline-decoration($light-background: true);
     &:not(.qg-private-content-link) {
       @include qg-link-unvisited-color {
         text-decoration-color: #457aa3;
@@ -71,7 +70,6 @@
       @include _qg-link-none-decoration;
     }
     @include qg-underline-on-highlight-decoration;
-    //@include qg-button-outline-decoration($light-background: true);
   }
 }
 

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -88,7 +88,7 @@
       @include _qg-link-none-decoration;
     }
     @include qg-underline-on-highlight-decoration;
-    @include qg-button-outline-decoration($light-background: true);
+    @include qg-button-outline-decoration;
   }
 }
 
@@ -101,7 +101,7 @@
     @include qg-link-decoration;
     @include qg-link-visited-decoration;
     @include qg-underline-on-highlight-decoration;
-    @include qg-button-outline-decoration($light-background: true);
+    @include qg-button-outline-decoration;
   }
 }
 
@@ -113,7 +113,7 @@
     @include qg-link-visited-decoration($qg-global-primary-darker-grey);
     text-decoration-color: #737678;
     @include qg-underline-on-highlight-decoration;
-    @include qg-button-outline-decoration($light-background: true);
+    @include qg-button-outline-decoration;
   }
 }
 
@@ -127,7 +127,7 @@
   @include qg-global-link-styles($margin) {
     @include qg-link-white;
     @include qg-link-decoration;
-    @include qg-button-outline-decoration($light-background: false);
+    @include qg-button-outline-decoration($outline-color: $qg-active-outline-brighter);
   }
 }
 
@@ -139,7 +139,7 @@
       @include _qg-link-none-decoration;
     }
     @include qg-underline-on-highlight-decoration;
-    @include qg-button-outline-decoration($light-background: false);
+    @include qg-button-outline-decoration($outline-color: $qg-active-outline-brighter);
   }
 }
 

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -19,7 +19,7 @@
     // &.hover {
     //   background: none;
     // }
-    //@include qg-button-outline-decoration($margin);
+    @include qg-button-outline-decoration($margin);
     @content;
   }
 }
@@ -54,7 +54,7 @@
     @include qg-link-decoration;
     @include qg-link-visited-decoration;
     @include qg-underline-on-highlight-decoration;
-    @include qg-button-outline-decoration($light-background: true);
+    //@include qg-button-outline-decoration($light-background: true);
     &:not(.qg-private-content-link) {
       @include qg-link-unvisited-color {
         text-decoration-color: #457aa3;
@@ -71,7 +71,7 @@
       @include _qg-link-none-decoration;
     }
     @include qg-underline-on-highlight-decoration;
-    @include qg-button-outline-decoration($light-background: true);
+    //@include qg-button-outline-decoration($light-background: true);
   }
 }
 
@@ -90,7 +90,7 @@
       @include _qg-link-none-decoration;
     }
     @include qg-underline-on-highlight-decoration;
-    @include qg-button-outline-decoration($light-background: false);
+    @include qg-button-outline-decoration($light-background: true);
   }
 }
 
@@ -103,7 +103,7 @@
     @include qg-link-decoration;
     @include qg-link-visited-decoration;
     @include qg-underline-on-highlight-decoration;
-    @include qg-button-outline-decoration($light-background: false);
+    @include qg-button-outline-decoration($light-background: true);
   }
 }
 
@@ -115,7 +115,7 @@
     @include qg-link-visited-decoration($qg-global-primary-darker-grey);
     text-decoration-color: #737678;
     @include qg-underline-on-highlight-decoration;
-    @include qg-button-outline-decoration($light-background: false);
+    @include qg-button-outline-decoration($light-background: true);
   }
 }
 

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -19,7 +19,7 @@
     // &.hover {
     //   background: none;
     // }
-    @include qg-button-outline-decoration($margin);
+    //@include qg-button-outline-decoration($margin);
     @content;
   }
 }
@@ -54,6 +54,7 @@
     @include qg-link-decoration;
     @include qg-link-visited-decoration;
     @include qg-underline-on-highlight-decoration;
+    @include qg-button-outline-decoration($light-background: true);
     &:not(.qg-private-content-link) {
       @include qg-link-unvisited-color {
         text-decoration-color: #457aa3;
@@ -70,6 +71,7 @@
       @include _qg-link-none-decoration;
     }
     @include qg-underline-on-highlight-decoration;
+    @include qg-button-outline-decoration($light-background: true);
   }
 }
 
@@ -88,6 +90,7 @@
       @include _qg-link-none-decoration;
     }
     @include qg-underline-on-highlight-decoration;
+    @include qg-button-outline-decoration($light-background: false);
   }
 }
 
@@ -100,6 +103,7 @@
     @include qg-link-decoration;
     @include qg-link-visited-decoration;
     @include qg-underline-on-highlight-decoration;
+    @include qg-button-outline-decoration($light-background: false);
   }
 }
 
@@ -111,6 +115,7 @@
     @include qg-link-visited-decoration($qg-global-primary-darker-grey);
     text-decoration-color: #737678;
     @include qg-underline-on-highlight-decoration;
+    @include qg-button-outline-decoration($light-background: false);
   }
 }
 

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -129,6 +129,7 @@
   @include qg-global-link-styles($margin) {
     @include qg-link-white;
     @include qg-link-decoration;
+    @include qg-button-outline-decoration($light-background: false);
   }
 }
 
@@ -140,6 +141,7 @@
       @include _qg-link-none-decoration;
     }
     @include qg-underline-on-highlight-decoration;
+    @include qg-button-outline-decoration($light-background: false);
   }
 }
 

--- a/src/assets/_project/_blocks/layout/header/_site-nav.scss
+++ b/src/assets/_project/_blocks/layout/header/_site-nav.scss
@@ -39,7 +39,7 @@
         background-color: transparent;
         border: 0;
         border-radius: 4px 4px 0 0;
-        padding: 16px 16px 5px;
+        padding: 12px 16px 12px;
     }
     .dropdown.mega-dropdown {
         position: static;

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -348,7 +348,7 @@ $text-underline-offset: 5px;
   @include on-active {
     outline-width: 3px;
     outline-style: solid;
-    @if $light-background {
+    @if $light-background == true {
       outline-color: $qg-active-outline;
     } @else {
       outline-color: $qg-active-outline-lighter;

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -20,7 +20,7 @@ $qg-outline-dark-hover: #313131;
 $qg-active-outline: #0096d6;
 
 // ## Active outlines on dark background ##
-$qg-active-outline-lighter: #00b4ff;
+$qg-active-outline-brighter: #00b4ff;
 
 // ## Dark grey ##
 $qg-dark-grey-lightest: #949494;
@@ -351,7 +351,7 @@ $text-underline-offset: 5px;
     @if $light-background == true {
       outline-color: $qg-active-outline;
     } @else {
-      outline-color: $qg-active-outline-lighter;
+      outline-color: $qg-active-outline-brighter;
     }
     outline-offset: 2px;
     border-radius: 0;

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -343,16 +343,12 @@ $qg-linkedin: #0077b5;
 
 $text-underline-offset: 5px;
 
-@mixin qg-button-outline-decoration($margin: 2px, $light-background: true) {
+@mixin qg-button-outline-decoration($margin: 2px, $outline-color: $qg-active-outline) {
   // Surround buttons and links with a blue outline when active/focused
   @include on-active {
     outline-width: 3px;
     outline-style: solid;
-    @if $light-background == true {
-      outline-color: $qg-active-outline;
-    } @else {
-      outline-color: $qg-active-outline-brighter;
-    }
+    outline-color: $outline-color;
     outline-offset: 2px;
     border-radius: 0;
     @content;

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -17,7 +17,7 @@ $qg-outline-dark: #00698f;
 $qg-outline-dark-hover: #313131;
 
 // ## Active outlines (transient) ##
-$qg-active-outline: #0096d6;
+$qg-active-outline: #00b4ff;
 
 // ## Dark grey ##
 $qg-dark-grey-lightest: #949494;
@@ -347,6 +347,7 @@ $text-underline-offset: 5px;
     outline-style: solid;
     outline-color: $qg-active-outline;
     outline-offset: 2px;
+    border-radius: 0;
     @content;
     * {
       // don't apply an extra outline to any children

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -16,8 +16,11 @@ $qg-green: #78ba00;
 $qg-outline-dark: #00698f;
 $qg-outline-dark-hover: #313131;
 
-// ## Active outlines (transient) ##
-$qg-active-outline: #00b4ff;
+// ## Active outlines on white background (transient) ##
+$qg-active-outline: #0096d6;
+
+// ## Active outlines on dark background ##
+$qg-active-outline-lighter: #00b4ff;
 
 // ## Dark grey ##
 $qg-dark-grey-lightest: #949494;
@@ -340,12 +343,16 @@ $qg-linkedin: #0077b5;
 
 $text-underline-offset: 5px;
 
-@mixin qg-button-outline-decoration ($margin: 2px) {
+@mixin qg-button-outline-decoration($margin: 2px, $light-background: true) {
   // Surround buttons and links with a blue outline when active/focused
   @include on-active {
     outline-width: 3px;
     outline-style: solid;
-    outline-color: $qg-active-outline;
+    @if $light-background {
+      outline-color: $qg-active-outline;
+    } @else {
+      outline-color: $qg-active-outline-lighter;
+    }
     outline-offset: 2px;
     border-radius: 0;
     @content;


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-314
https://oss-uat.clients.squiz.net/health/services/travel/subsidies/ptss-subsidies

- Introducing #00B4FF as $qg-active-outline-brighter for darker backgrounds
- Introducing a second argument to `qg-button-outline-decoration` mixin called `$light-background`, so when the background is light, the outline color will be` $qg-active-outline`(#0096d6), if the background color is darker like the nav bar, the outline color will be `qg-active-outline-brighter`(#00b4ff).
- Removing border-radius on the outline so it looks square consistent with other link outlines.
- Updating nav-link padding to center the word in the outline
- This also fixes the missing underline on Print link (confirmed with Bec that it is needed)
- Also fixes the missing underline on the accordion headers when hovered

Before:
![image](https://user-images.githubusercontent.com/126438691/226516446-5233c9f7-71b1-4e8d-b88d-621d0852ae4d.png)

After:
![image](https://user-images.githubusercontent.com/126438691/226516569-8c4a2465-5a04-49e4-b795-1403baf70a43.png)
