### PR TITLE
Qoldev 331 logo outline

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -5,7 +5,7 @@
 //-------------------------------------------------
 
 // global link styles
-@mixin qg-global-link-styles($margin: 2px) {
+@mixin qg-global-link-styles($margin: 2px, $outline-color: $qg-active-outline) {
   // make exception for certain classes, which need to re-visit for better optimization
   &:not(.qg-feature-box .qg-link):not(.qg-index a.qg-index-item):not(.page-item
       .page-link):not(.dfv-cards--type-top-prompt
@@ -19,7 +19,7 @@
     // &.hover {
     //   background: none;
     // }
-    @include qg-button-outline-decoration($margin);
+    @include qg-button-outline-decoration($margin, $qg-active-outline);
     @content;
   }
 }
@@ -94,7 +94,7 @@
 
 // 2. color theme black with underline
 @mixin qg-link-styles__theme-black($margin: 2px) {
-  @include qg-global-link-styles($margin) {
+  @include qg-global-link-styles($margin: $margin) {
     @include qg-link-unvisited-color($qg-global-primary-darker-grey) {
       text-decoration-color: #737678;
     }
@@ -124,7 +124,7 @@
 // START theme WHITE
 // 2. With underline
 @mixin qg-link-styles__theme-white($margin: 2px) {
-  @include qg-global-link-styles($margin) {
+  @include qg-global-link-styles($margin: $margin) {
     @include qg-link-white;
     @include qg-link-decoration;
     @include qg-button-outline-decoration($outline-color: $qg-active-outline-brighter);

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -19,7 +19,7 @@
     // &.hover {
     //   background: none;
     // }
-    @include qg-button-outline-decoration($margin, $qg-active-outline);
+    @include qg-button-outline-decoration($margin, $outline-color);
     @content;
   }
 }

--- a/src/assets/_project/_blocks/layout/header/_coat-of-arms.scss
+++ b/src/assets/_project/_blocks/layout/header/_coat-of-arms.scss
@@ -4,7 +4,7 @@
   overflow: hidden;
 
   a {
-    @include qg-global-link-styles;
+    @include qg-global-link-styles($outline-color: $qg-active-outline-brighter);
   }
 
   img {


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-331

Brightening the outline color for the logo to be consistent with the nav items.

Before:
![image](https://user-images.githubusercontent.com/126438691/228094570-0e80ae45-20fd-48ac-a11c-16982b08d299.png)


After:
![image](https://user-images.githubusercontent.com/126438691/228095290-70bed362-738b-4811-940c-4d4c1fce045d.png)

