### PR TITLE
QOLDEV-34 Improving primary button focus state

### DIFF
--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -74,7 +74,7 @@
 
 .qg-btn {
   @extend .btn;
-  @include qg-button-outline-decoration;
+  @include qg-button-outline-decoration($border-radius: $btn-border-radius-base);
   border-radius: $btn-border-radius-base;
 
   &.btn-outline-dark{

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -343,14 +343,15 @@ $qg-linkedin: #0077b5;
 
 $text-underline-offset: 5px;
 
-@mixin qg-button-outline-decoration($margin: 2px, $outline-color: $qg-active-outline) {
+@mixin qg-button-outline-decoration($margin: 2px, $outline-color: $qg-active-outline, $border-radius: 0) {
   // Surround buttons and links with a blue outline when active/focused
   @include on-active {
     outline-width: 3px;
     outline-style: solid;
     outline-color: $outline-color;
     outline-offset: 2px;
-    border-radius: 0;
+    border-radius: $border-radius;
+    box-shadow: none;
     @content;
     * {
       // don't apply an extra outline to any children


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-34

From Bec:

Focus state - looks like it’s still inheriting a box-shadow from Bootstrap styles.
Focus and active state – Text should be underlined. Also, can the outline have rounded corners to match the button?

https://oss-uat.clients.squiz.net/forgov-dev/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/buttons#primary