### PR TITLE
Qoldev 335 link styles in site wide alert

### DIFF
--- a/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
+++ b/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
@@ -1,5 +1,5 @@
 // content alert and global alert styles
-.alert {
+.alert, .qg-site-wide-alert {
   position: relative;
   color: #000;
   & > :first-child{

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -59,6 +59,7 @@
         text-decoration-color: #457aa3;
       }
     }
+    text-underline-offset: $text-underline-offset;
   }
 }
 

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -59,8 +59,8 @@
         text-decoration-color: #457aa3;
       }
     }
-    text-underline-offset: $text-underline-offset;
   }
+  text-underline-offset: $text-underline-offset;
 }
 
 // 2. color theme blue no underline

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -60,7 +60,6 @@
       }
     }
   }
-  text-underline-offset: $text-underline-offset;
 }
 
 // 2. color theme blue no underline


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-335

The underline cutting through letters like y and p is noticeable.

Before:
https://www.qld.gov.au/forgov-dev/mail-facilities-and-vehicles/vehicles/qfleet
![image](https://user-images.githubusercontent.com/126438691/228429030-e2eb7590-d507-4d17-ab41-57459d78b536.png)

After:
https://oss-uat.clients.squiz.net/forgov-dev/mail-facilities-and-vehicles/vehicles/qfleet
![image](https://user-images.githubusercontent.com/126438691/228428952-9cbf41a7-50f4-4e40-8641-10cf1010fe2a.png)
