### PR TITLE
Qoldev 343 Styling underline in alert danger

### DIFF
--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -392,7 +392,6 @@
   //error alert
   .alert-danger {
     li {
-      text-decoration-line: underline;
       span {
         color: $SecondaryColor;
       }

--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -392,6 +392,8 @@
   //error alert
   .alert-danger {
     li {
+      text-decoration-line: underline;
+      text-underline-offset: $text-underline-offset;
       span {
         color: $SecondaryColor;
       }

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -11,9 +11,8 @@
       .page-link):not(.dfv-cards--type-top-prompt
       a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.qg-aside-button):not(.dfv-back
       a):not(.QSAR-records-search a):not(.dfv-content a.qg-links-list__link) {
-    &:not(span[role=link] *) {
-      text-underline-offset: $text-underline-offset;
-    }
+
+    text-underline-offset: $text-underline-offset;
     // not sure why Asif need to add this, which will have side-effect on customised style added by franchise.
     // &:hover,
     // &.hover {

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -296,9 +296,7 @@ $qg-linkedin: #0077b5;
 @mixin qg-link-underline {
   text-decoration-line: underline;
   text-decoration-style: solid;
-  &:not(span[role=link] *) {
-    text-underline-offset: $text-underline-offset;
-  }
+  text-underline-offset: $text-underline-offset;
 }
 @mixin _qg-link-underline-thicker {
   @include qg-link-underline;

--- a/src/stories/components/Forms/templates/Validation.html
+++ b/src/stories/components/Forms/templates/Validation.html
@@ -3,17 +3,17 @@
   <p></p>
   <ul>
     <li>
-      <span data-component-key="general.comments" ref="errorRef" tabindex="0" role="link">
+      <span data-component-key="general.comments" ref="errorRef" tabindex="0">
         Comments is required
       </span>
     </li>
     <li>
-      <span data-component-key="contact.howWouldYouLikeToBeContacted" ref="errorRef" tabindex="0" role="link">
+      <span data-component-key="contact.howWouldYouLikeToBeContacted" ref="errorRef" tabindex="0">
         How would you like to be contacted? is required
       </span>
     </li>
     <li>
-      <span data-component-key="contact.privacyAcknowledgement.iHaveReadAndUnderstoodTheAHrefPrivacyStatementA" ref="errorRef" tabindex="0" role="link">
+      <span data-component-key="contact.privacyAcknowledgement.iHaveReadAndUnderstoodTheAHrefPrivacyStatementA" ref="errorRef" tabindex="0">
         I have read and understood the <a href="https://www.qld.gov.au/contact-us/contact-us-online-form-privacy-statement" target="_blank" rel="nofollow noopener" title="Opens in new window">privacy statement<span class="qg-blank-notice sr-only"> (Opens in new window)</span></a> is required
       </span>
     </li>

--- a/src/stories/components/Forms/templates/Validation.html
+++ b/src/stories/components/Forms/templates/Validation.html
@@ -3,17 +3,17 @@
   <p></p>
   <ul>
     <li>
-      <span data-component-key="general.comments" ref="errorRef" tabindex="0">
+      <span data-component-key="general.comments" ref="errorRef" tabindex="0" role="link">
         Comments is required
       </span>
     </li>
     <li>
-      <span data-component-key="contact.howWouldYouLikeToBeContacted" ref="errorRef" tabindex="0">
+      <span data-component-key="contact.howWouldYouLikeToBeContacted" ref="errorRef" tabindex="0" role="link">
         How would you like to be contacted? is required
       </span>
     </li>
     <li>
-      <span data-component-key="contact.privacyAcknowledgement.iHaveReadAndUnderstoodTheAHrefPrivacyStatementA" ref="errorRef" tabindex="0">
+      <span data-component-key="contact.privacyAcknowledgement.iHaveReadAndUnderstoodTheAHrefPrivacyStatementA" ref="errorRef" tabindex="0" role="link">
         I have read and understood the <a href="https://www.qld.gov.au/contact-us/contact-us-online-form-privacy-statement" target="_blank" rel="nofollow noopener" title="Opens in new window">privacy statement<span class="qg-blank-notice sr-only"> (Opens in new window)</span></a> is required
       </span>
     </li>


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-343

https://oss-uat.clients.squiz.net/contact-us

When you submit contact us form without the required fields:
![image](https://user-images.githubusercontent.com/126438691/229980380-d05ab956-dd6e-4b2f-aa01-b35c47cedce0.png)

Form io also needs to be updated to remove role='link' from the span. Otherwise the underline will be still there.

