### PR TITLE
QOLDEV-322 Fixing logo outline in FF and Safari

### DIFF
--- a/src/assets/_project/_blocks/layout/header/_coat-of-arms.scss
+++ b/src/assets/_project/_blocks/layout/header/_coat-of-arms.scss
@@ -5,6 +5,7 @@
 
   a {
     @include qg-global-link-styles($outline-color: $qg-active-outline-brighter);
+    display: inline-block;
   }
 
   img {


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-322

Safari before:
![image](https://user-images.githubusercontent.com/126438691/230282593-a0f9d7e9-1817-494e-a933-9a391d5a5dac.png)

FireFox before:
![image](https://user-images.githubusercontent.com/126438691/230282759-b04f6d2b-7899-42ca-a267-92b582c0771f.png)

After:
![image](https://user-images.githubusercontent.com/126438691/230282887-7d57af9d-38cb-4f4b-bd84-46c04ce14bf4.png)
