### PR TITLE
QOLDEV-34 Removing box-shadow for focus and active states together

### DIFF
--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -74,10 +74,16 @@
 }
 
 .qg-btn {
+  &.btn-primary, &.btn-outline-dark, &.btn-outline-light, &.btn-default {
+    @include on-active {
+      box-shadow: none;
+    }
+  }
+}
+
+.qg-btn {
   @extend .btn;
   @include qg-button-outline-decoration($border-radius: $btn-border-radius-base);
-  border-radius: $btn-border-radius-base;
-
   &.btn-outline-dark{
     color: $qg-outline-dark;
     background-color: transparent !important;
@@ -91,7 +97,7 @@
   &.btn-outline-light{
     color: white !important;
     background-color: transparent !important;
-    border:3px solid white;
+    border: 3px solid white;
     @include qg-underline-on-highlight-decoration;
   }
   &.btn-link.light{

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -351,7 +351,7 @@ $text-underline-offset: 5px;
     outline-color: $outline-color;
     outline-offset: 2px;
     border-radius: $border-radius;
-    box-shadow: none;
+    box-shadow: none !important;
     @content;
     * {
       // don't apply an extra outline to any children

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -276,6 +276,7 @@ $qg-linkedin: #0077b5;
 @mixin on-active() {
   &:active,
   &:focus, &.focus,
+  &:active:focus,
   &:focus-visible, &:focus-within {
     &:not(:disabled, .disabled) {
       @content;
@@ -351,7 +352,8 @@ $text-underline-offset: 5px;
     outline-color: $outline-color;
     outline-offset: 2px;
     border-radius: $border-radius;
-    box-shadow: none !important;
+    box-shadow: none;
+
     @content;
     * {
       // don't apply an extra outline to any children


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-34

It was working as expected when focus only and active only.
However when it is  focused and active together, the box-shadow appears. This change is to overwrite bootstrap's box-shadow value.
https://oss-uat.clients.squiz.net/forgov-dev/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/buttons