### PR TITLE
Qoldev 37 tertiary btn improvement

### DIFF
--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -67,9 +67,11 @@
 }
 
 .btn-link {
-  @include qg-link-styles__default;
+  @include qg-button-outline-decoration($border-radius: $btn-border-radius-base);
   @include all-states {
-    color: $qg-blue-dark;
+    &:not(.light) {
+      color: $qg-blue-dark;
+    }
   }
 }
 


### PR DESCRIPTION
- Fixing the text color for .btn-link.light
- Making tertiary button's outline with border-radius: 4px instead of 0

https://oss-uat.clients.squiz.net/forgov-dev/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/buttons