### PR TITLE
QOLDEV-301 Handling aria-expanded on the searchbox

### DIFF
--- a/src/assets/_project/_blocks/components/site-search/qg-site-search.js
+++ b/src/assets/_project/_blocks/components/site-search/qg-site-search.js
@@ -87,14 +87,15 @@ $(function () {
   // Handle clicking into the input field
   qgSiteSearch.fn.onFocus = function (inputValue, targetInput) {
     var initialConcierge = targetInput.parent().find($('.qg-search-concierge-initial'));
+    // Toggle aria-expanded for the search input
+    targetInput.attr('aria-expanded', 'true');
+
     if (inputValue === '') {
       // Transition reveal initial state
       initialConcierge.addClass('show');
     } else {
       qgSiteSearch.fn.checkForSuggestions(inputValue, targetInput);
     }
-    // Toggle aria-expanded for the search input
-    targetInput.attr('aria-expanded', 'true');
   };
 
   // Handle clicking out of the input field
@@ -112,13 +113,13 @@ $(function () {
     var initialConcierge = targetInput.parent().find($('.qg-search-concierge-initial'));
     var helpfulConcierge = targetInput.parent().find($('.qg-search-concierge-help'));
     var clearButton = targetInput.parent().find($('.qg-search-close-concierge'));
+
     if (keyCode === 40) {
       targetInput.parents($('.qg-site-search__form')).attr('data-navindex', '0');
       setTimeout($('.qg-search-concierge.show').find('a, button')[0].focus(), 300);
     } else if (inputValue !== '') {
       // Reveal the clear button
       clearButton.removeClass('hide');
-
       // Look for suggested results
       qgSiteSearch.fn.checkForSuggestions(inputValue, targetInput);
     } else {
@@ -128,6 +129,11 @@ $(function () {
       // Remove suggestions and transition reveal initial state
       initialConcierge.addClass('show');
       helpfulConcierge.removeClass('show');
+    }
+    if (initialConcierge.hasClass('show') || helpfulConcierge.hasClass('show')) {
+      targetInput.attr('aria-expanded', 'true');
+    } else {
+      targetInput.attr('aria-expanded', 'false');
     }
   };
 
@@ -249,7 +255,6 @@ $(function () {
 
     // Remove initial state
     initialConcierge.removeClass('show');
-    targetInput.attr('aria-expanded', 'false');
 
     // Query Funnelback when three characters are entered
     if (numChars >= 3) {
@@ -261,7 +266,6 @@ $(function () {
 
       // Transition reveal suggestions
       helpfulConcierge.addClass('show');
-      targetInput.attr('aria-expanded', 'true');
     }
   };
 
@@ -320,6 +324,7 @@ $(function () {
       suggestionsHTML += '</div>';
     } else {
       targetInput.parent().find($('.qg-search-concierge-help')).hide();
+      targetInput.attr('aria-expanded', 'false');
     }
     // Update the concierge container
     suggestionsContainer.html(suggestionsHTML);

--- a/src/assets/_project/_blocks/components/site-search/qg-site-search.js
+++ b/src/assets/_project/_blocks/components/site-search/qg-site-search.js
@@ -93,6 +93,8 @@ $(function () {
     } else {
       qgSiteSearch.fn.checkForSuggestions(inputValue, targetInput);
     }
+    // Toggle aria-expanded for the search input
+    targetInput.attr('aria-expanded', 'true');
   };
 
   // Handle clicking out of the input field
@@ -224,10 +226,14 @@ $(function () {
   qgSiteSearch.fn.closeConciergePanels = function () {
     var initialConcierge = $('.qg-search-concierge-initial');
     var helpfulConcierge = $('.qg-search-concierge-help');
+    var targetInput = $('.qg-search-site__input');
 
     // Immediately close both concierge panels
     initialConcierge.addClass('hide').removeClass('show');
     helpfulConcierge.addClass('hide').removeClass('show');
+
+    // Toggle aria-expanded for the search input
+    targetInput.attr('aria-expanded', 'false');
 
     setTimeout(function () {
       initialConcierge.removeClass('hide');
@@ -243,6 +249,7 @@ $(function () {
 
     // Remove initial state
     initialConcierge.removeClass('show');
+    targetInput.attr('aria-expanded', 'false');
 
     // Query Funnelback when three characters are entered
     if (numChars >= 3) {
@@ -254,6 +261,7 @@ $(function () {
 
       // Transition reveal suggestions
       helpfulConcierge.addClass('show');
+      targetInput.attr('aria-expanded', 'true');
     }
   };
 

--- a/src/assets/_project/_blocks/layout/site-search-form.html
+++ b/src/assets/_project/_blocks/layout/site-search-form.html
@@ -1,7 +1,7 @@
 <form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
     <div class="input-group">
       <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-      <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+      <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
       <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
         <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
           <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/breadcrumb.html
+++ b/src/docs/examples/breadcrumb.html
@@ -237,7 +237,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/cut-in.html
+++ b/src/docs/examples/cut-in.html
@@ -228,7 +228,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/form-new-styles.html
+++ b/src/docs/examples/form-new-styles.html
@@ -200,7 +200,7 @@
       </button><form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/formio.html
+++ b/src/docs/examples/formio.html
@@ -197,7 +197,7 @@
       </button><form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/guide-page.html
+++ b/src/docs/examples/guide-page.html
@@ -192,7 +192,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/index.html
+++ b/src/docs/examples/index.html
@@ -138,7 +138,7 @@
       <form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
         <div class="input-group">
           <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-          <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+          <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
           <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
             <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
               <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/recaptcha2.html
+++ b/src/docs/examples/recaptcha2.html
@@ -245,7 +245,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/search-page.html
+++ b/src/docs/examples/search-page.html
@@ -235,7 +235,7 @@
       <form id="qg-global-search-form" action="https://www.qld.gov.au/search" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/section-nav-example.html
+++ b/src/docs/examples/section-nav-example.html
@@ -226,7 +226,7 @@
       </button><form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" class="form-control" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/docs/examples/service-finder.html
+++ b/src/docs/examples/service-finder.html
@@ -341,7 +341,7 @@
       <form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete qg-sf-global" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
       <div class="input-group">
         <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-        <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" accesskey="5" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false"/>
+        <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" accesskey="5" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
         <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
           <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
             <g transform="translate(67.298684, 71.201316)">

--- a/src/stories/components/Header/templates/Search.html
+++ b/src/stories/components/Header/templates/Search.html
@@ -1,7 +1,7 @@
 <form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete qg-site-search__form" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&amp;fmt=json%2B%2B&amp;alpha=0.5&amp;profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&amp;profile=qld&amp;smeta_sfinder_sand=yes" novalidate="true">
     <div class="input-group">
       <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
-      <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false">
+      <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox">
       <svg class="qg-search__icon" width="512px" height="512px" viewBox="0 0 512 512">
         <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
           <g transform="translate(67.298684, 71.201316)">


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-301

I found a valid example of a searchob with suggesting keywords on bootstrap website: https://getbootstrap.com/docs/4.3/components/

It has aria-expanded attribute which toggles accordingly. This PR is to implement toggling aria-expanded on the searchbox.
We need to add role='combobox' to the <input>, otherwise the screenreaders won't announce the input box expandable.
The same change should go to Squiz to the related asset Id.