### PR TITLE
QOLDEV-302 Removing maximum and minimum scale from viewport

### DIFF
--- a/.storybook/previewMainTemplate.ejs
+++ b/.storybook/previewMainTemplate.ejs
@@ -8,7 +8,7 @@
     <link rel="shortcut icon" href="<%= htmlWebpackPlugin.files.favicon%>" />
     <% } %>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, minimum-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css" />
     <link href="./assets/v4/latest/css/qg-main.css" rel="stylesheet" type="text/css" media="all">
     <noscript>

--- a/src/assets/_project/_blocks/layout/head-assets.html
+++ b/src/assets/_project/_blocks/layout/head-assets.html
@@ -1,6 +1,6 @@
 <meta name="DCTERMS.license" scheme="DCTERMS.URI" content="https://creativecommons.org/licenses/by/4.0/">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, minimum-scale=1.0">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <link rel="schema.DCTERMS" href="http://purl.org/dc/terms/">
 <link rel="schema.AGLSTERMS" href="https://agls.gov.au/documents/aglsterms/">

--- a/src/docs/examples/cut-in.html
+++ b/src/docs/examples/cut-in.html
@@ -9,7 +9,7 @@
 
   <!-- Misc Metadata test-->
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!--[if (lt IE 9)|(gt IE 10) ]><link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if !IE]><!--><link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css" /><!--<![endif]-->
 

--- a/src/docs/examples/formio.html
+++ b/src/docs/examples/formio.html
@@ -17,7 +17,7 @@
 
   <!-- Misc Metadata test-->
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!--[if (lt IE 9)|(gt IE 10) ]><link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if !IE]><!--><link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css" /><!--<![endif]-->
 

--- a/src/docs/examples/index.html
+++ b/src/docs/examples/index.html
@@ -39,7 +39,7 @@
   <meta name="DCTERMS.license" scheme="DCTERMS.URI" content="https://creativecommons.org/licenses/by/4.0/">
 
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <link rel="shortcut icon" href="/assets/v4/latest/images/favicon.ico">
 

--- a/src/docs/examples/search-page.html
+++ b/src/docs/examples/search-page.html
@@ -15,7 +15,7 @@
 
   <!-- Misc Metadata test-->
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!--[if (lt IE 9)|(gt IE 10) ]><link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if !IE]><!--><link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css" /><!--<![endif]-->
 

--- a/src/docs/examples/service-finder.html
+++ b/src/docs/examples/service-finder.html
@@ -17,7 +17,7 @@
 
   <!-- Misc Metadata test-->
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, minimum-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!--[if (lt IE 9)|(gt IE 10) ]><link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css" /><![endif]-->
   <!--[if !IE]><!--><link href="//fonts.googleapis.com/css?family=Lato:100,300,400,700,900,100italic,300italic,400italic,700italic,900italic" rel="stylesheet" type="text/css" /><!--<![endif]-->
 


### PR DESCRIPTION
Removing max and min scale from the viewport.
https://webhint.io/docs/user-guide/hints/hint-meta-viewport/?source=devtools

_These properties can block the user from zooming on a page. With such a wide range of devices available with different display dimensions, screen resolutions, pixel densities, etc., it is difficult to choose an appropriate text size in a design. Most of the time using these properties enable users to pick a text size that is unreadable while preventing them from zooming, frustrating them, or making the web site/app inaccessible in some cases._