### PR TITLE
QOLDEV-34 Generalising all buttons states

### DIFF
--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -109,5 +109,7 @@
 
 #body .qg-btn, #body .btn, body .qg-btn, body .btn {
   // override default .btn styling
-  @include qg-underline-on-highlight-decoration;
+  @include all-states {
+    @include qg-button-outline-decoration($border-radius: $btn-border-radius-base);
+  }
 }


### PR DESCRIPTION
This change would make buttons that don't have qg-btn class to inherit SWE styles.
Example: The submit button on https://oss-uat.clients.squiz.net/contact-us
