### PR TITLE
QOLDEV-206 Index page, no underline for all sreen sizes

### DIFF
--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -106,11 +106,9 @@
 // of other index-links rules
 #qg-content #qg-primary-content .qg-index-links {
   h2 a, ul li a {
+    @include qg-link-styles__no-underline-default;
     @include breakpoint(xs) {
       @include qg-link-styles__theme-white(0);
-    }
-    @include media-breakpoint-up(sm) {
-      @include qg-link-styles__no-underline-default;
     }
   }
 }


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/disability
Removing underline from the item headers in mobile view as well as desktop based on the new requirements. So they look like buttons:

![image](https://user-images.githubusercontent.com/126438691/232996738-2f057acc-f591-43f7-bd53-846cb3ef05e3.png)
