### PR TITLE
Qoldev 226 improving card default state

### DIFF
--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -7,6 +7,10 @@
       @include all-states {
         @include qg-button-outline-decoration($border-radius: $btn-border-radius-base);
       }
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+      &:hover {
+        box-shadow: none;
+      }
     }
   }
 


### PR DESCRIPTION
Adding box-shadow for clickable cards in default state only.

Example:
https://oss-uat.clients.squiz.net/forgov-dev/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/cards
https://oss-uat.clients.squiz.net/jobs/jobs-and-training-support