### PR TITLE
Qoldev 44 blurb text color

### DIFF
--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -53,7 +53,7 @@
     margin: 0 15px;
     padding: 1em;
     width: 27.5em;
-    .qg-btn {
+    .qg-btn, a {
       @include media-breakpoint-up(sm) {
         @include qg-link-styles__theme-white($border-radius: $btn-border-radius-base);
       }


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/health/conditions/health-alerts/coronavirus-covid-19

Desktop: link color should be white
![image](https://user-images.githubusercontent.com/126438691/235590706-ede4ad18-42c8-4438-8c89-2aeffebc8609.png)

Mobile: link color as standard
![image](https://user-images.githubusercontent.com/126438691/235590810-784406c7-cc75-45e6-9631-f6081f98a23c.png)
