### PR TITLE
QOLDEV-44 Text color on services dropdown, applying standard hyperlinks rules

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -95,7 +95,7 @@
 @mixin qg-link-styles__theme-black($margin: 2px 2px 2px 0) {
   @include qg-global-link-styles($margin: $margin) {
     @include qg-link-unvisited-color($qg-global-primary-darker-grey) {
-      text-decoration-color: #737678;
+      text-decoration-color: $qg-global-primary-text-decoration-grey;
     }
     @include qg-link-decoration;
     @include qg-link-visited-decoration;
@@ -105,12 +105,12 @@
 }
 
 // Black theme that doesn't change when visited
-@mixin qg-link-styles__theme-black-always {
+@mixin qg-link-styles__theme-black-always($text-color: $qg-global-primary-darker-grey, $text-decoration-color: $qg-global-primary-text-decoration-grey) {
   @include qg-global-link-styles {
-    color: $qg-global-primary-darker-grey;
+    color: $text-color;
     @include qg-link-decoration;
-    @include qg-link-visited-decoration($qg-global-primary-darker-grey);
-    text-decoration-color: #737678;
+    @include qg-link-visited-decoration($text-color);
+    text-decoration-color: $text-decoration-color;
     @include qg-underline-on-highlight-decoration;
     @include qg-button-outline-decoration;
   }

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -64,12 +64,11 @@
       }
     }
     .qg-service-finder__container .qg-search-concierge-content {
-      ul li a {
-        @include qg-link-styles__theme-black-always;
-        text-decoration-color: $qg-global-primary-darker-grey !important;
+      a {
+        @include qg-link-styles__theme-black-always(black, $qg-global-primary-darker-grey);
       }
       > a {
-        padding: 20px, 35px, 0, 35px;
+        padding: 20px 35px 0 35px;
       }
     }
     &.light{

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -53,9 +53,23 @@
     margin: 0 15px;
     padding: 1em;
     width: 27.5em;
-    .qg-btn, a {
+    .qg-btn {
       @include media-breakpoint-up(sm) {
         @include qg-link-styles__theme-white($border-radius: $btn-border-radius-base);
+      }
+    }
+    & > a {
+      @include media-breakpoint-up(sm) {
+        @include qg-link-styles__theme-white;
+      }
+    }
+    .qg-service-finder__container .qg-search-concierge-content {
+      ul li a {
+        @include qg-link-styles__theme-black-always;
+        text-decoration-color: $qg-global-primary-darker-grey !important;
+      }
+      > a {
+        padding: 20px, 35px, 0, 35px;
       }
     }
     &.light{

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -245,6 +245,7 @@ $qg-global-primary-hover:#CCDFE7;
 $qg-global-primary-grey: #565656;
 $qg-global-primary-dark-grey: #313131;
 $qg-global-primary-darker-grey: #292929;
+$qg-global-primary-text-decoration-grey: #737678;
 $qg-global-primary-light-grey: #f3f3f3;
 $qg-global-primary-hover-grey:#CCC;
 


### PR DESCRIPTION
This fix is to make both the blurb on https://oss-uat.clients.squiz.net/health/conditions/health-alerts/coronavirus-covid-19 and the dropdwn on the search box on https://oss-uat.clients.squiz.net/services work as expected in desktop and mobile view. The first one has white text in desktop view, the second one has black text in all screens.

Previously the link in the dropdown were all white.

Also the links within the dropdown in services searchbox did not have the SWE hyperlink style, like the underline offset. This is now fixed.

![image](https://user-images.githubusercontent.com/126438691/235814531-679818b7-0d18-4f5f-9031-1dbe07075591.png)

![image](https://user-images.githubusercontent.com/126438691/235814576-9238e488-3c88-47ac-af49-b40e5257ac0d.png)
