### PR TITLE
Qoldev 379 franchise cards

### DIFF
--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -1,9 +1,9 @@
-@mixin qg-card {
+@mixin qg-card($margin: 0) {
   color: white;
   display: flex;
 
   > a {
-    margin: 0;
+    margin: $margin;
   }
 
   &.qg-card__clickable {

--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -1,10 +1,9 @@
-@mixin qg-card($margin: 0) {
+#qg-content ul.featured-section .qg-card > a {
+  margin: 0;
+}
+@mixin qg-card {
   color: white;
   display: flex;
-
-  > a {
-    margin: $margin !important;
-  }
 
   &.qg-card__clickable {
     .content {

--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -2,6 +2,10 @@
   color: white;
   display: flex;
 
+  > a {
+    margin: 0;
+  }
+
   &.qg-card__clickable {
     .content {
       @include all-states {

--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -1,5 +1,5 @@
 #qg-content ul.featured-section .qg-card > a {
-  margin: 0;
+  margin: 0 !important;
 }
 @mixin qg-card {
   color: white;

--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -3,7 +3,7 @@
   display: flex;
 
   > a {
-    margin: $margin;
+    margin: $margin !important;
   }
 
   &.qg-card__clickable {


### PR DESCRIPTION
Homepage
https://oss-uat.clients.squiz.net/

![image](https://user-images.githubusercontent.com/126438691/236122999-adadebac-6284-43ed-9981-894be9dbd428.png)

This bug comes from the default 2px margin applied to all links around the system. This type of card is not one of our standard card defined in the document. It is done by the franchise.

I could also could do:
![image](https://user-images.githubusercontent.com/126438691/236360541-4f132d29-cf4f-41df-bd00-0616c02fdb88.png)

However I thought the code committed is safer and only impacts feature-section class.