### PR TITLE
QOLDEV-359 cdn release fix branchnames

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -110,7 +110,7 @@ gulp.task('serve', require('./gulp/build-tasks/serve')(gulp, plugins, connect, c
 /* PUBLISH TASKS */
 // web template release
 gulp.task('wt-clean', require('./gulp/publish-tasks/git').clean(config.webTemplateRepo.folder));
-gulp.task('wt-clone', require('./gulp/publish-tasks/git').clone(config.webTemplateRepo.url, config.webTemplateRepo.folder));
+gulp.task('wt-clone', require('./gulp/publish-tasks/git').clone(config.webTemplateRepo.url, config.webTemplateRepo.folder, false));
 
 // wt-branch task creates a test branch on 'web-template-release'.
 gulp.task('wt-branch', require('./gulp/publish-tasks/git').branch(config.webTemplateRepo.folder, argv));
@@ -123,18 +123,17 @@ gulp.task('wt-push', require('./gulp/publish-tasks/git').push(config.webTemplate
 
 // CDN release
 gulp.task('cdn-clean', require('./gulp/publish-tasks/git').clean(config.staticCdnRepo.folder));
-gulp.task('cdn-clone', require('./gulp/publish-tasks/git').clone(config.staticCdnRepo.url, config.staticCdnRepo.folder));
+gulp.task('cdn-clone', require('./gulp/publish-tasks/git').clone(config.staticCdnRepo.url, config.staticCdnRepo.folder, true));
 gulp.task('cdn-transfer', require('./gulp/publish-tasks/git').transfer());
 gulp.task('cdn-add', require('./gulp/publish-tasks/git').add(config.staticCdnRepo.folder));
 gulp.task('cdn-branch', require('./gulp/publish-tasks/git').branch(config.staticCdnRepo.folder, argv));
 gulp.task('cdn-commit', require('./gulp/publish-tasks/git').commit(config.staticCdnRepo.folder, pjson.version));
-gulp.task('cdn-branch', require('./gulp/publish-tasks/git').branch(config.staticCdnRepo.folder));
-gulp.task('cdn-push', require('./gulp/publish-tasks/git').push(config.staticCdnRepo.folder));
+gulp.task('cdn-push', require('./gulp/publish-tasks/git').push(config.staticCdnRepo.folder, argv));
 
 // SWE release
 gulp.task('swe-add', require('./gulp/publish-tasks/git').add());
 gulp.task('swe-commit', require('./gulp/publish-tasks/git').commit('./', pjson['version']));
-gulp.task('swe-push', require('./gulp/publish-tasks/git').push('./'));
+gulp.task('swe-push', require('./gulp/publish-tasks/git').push('./', argv));
 gulp.task('swe-tag', require('./gulp/publish-tasks/git').tag('./', pjson['version']));
 
 /* WATCH TASKS */


### PR DESCRIPTION
**argv.branch bug fix**
Fixes "undefined" bug on argv.branch variable.  Update git.js BRANCH() and PUSH() functions to test for property.

**SSH Flag**
Add a "SSH" flag to the git.js COMMIT() function, which allows calling functions to optionally specify an SSH protocol instead of HTTPS.  Used when switching between internal and network publishing routes.