### PR TITLE
Qoldev 44 services blurb text color

### DIFF
--- a/e2e/__tests__/components/call-out-box-test.js
+++ b/e2e/__tests__/components/call-out-box-test.js
@@ -15,7 +15,7 @@ describe('SWE Components testing', () => {
     page.on('console', consoleObj => { consoleMsg = consoleObj.text(); });
     await page.goto(`${ct.APP_URL}/docs/components/call-out-box.html`, { waitUntil: 'networkidle0' });
     // 1. -> call out box contains deprecate icon
-    await page.waitForSelector('.qg-callout__box .qg-callout__icon i.fa');
+    await page.waitForSelector('.qg-callout__box .qg-callout__icon span.fa');
     // 2. -> warning appears in console
     await page.waitForTimeout(5000);
     expect(consoleMsg).toEqual('Please change the font awesome element in Callout box from i to span, we\'ll be removing the css in this element before 22nd june 2022. Please refer to the https://github.com/qld-gov-au/qg-web-template/pull/391 for more details.');

--- a/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
+++ b/src/assets/_project/_blocks/components/buttons/_qg-buttons.scss
@@ -52,6 +52,7 @@
 
 .btn-secondary {
   @include button-variant($qg-blue, transparent);
+  color: white !important;
   @include on-hover {
     background-color: $qg-blue-hover;
   }

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -53,9 +53,10 @@
     margin: 0 15px;
     padding: 1em;
     width: 27.5em;
-    .qg-btn {
+    .qg-btn:not(.btn-primary) {
       @include media-breakpoint-up(sm) {
         @include qg-link-styles__theme-white($border-radius: $btn-border-radius-base);
+        text-decoration: none;
       }
     }
     & > a:not(.qg-btn) {

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -58,7 +58,7 @@
         @include qg-link-styles__theme-white($border-radius: $btn-border-radius-base);
       }
     }
-    & > a {
+    & > a:not(.qg-btn) {
       @include media-breakpoint-up(sm) {
         @include qg-link-styles__theme-white;
       }

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -53,12 +53,6 @@
     margin: 0 15px;
     padding: 1em;
     width: 27.5em;
-    .qg-btn:not(.btn-primary) {
-      @include media-breakpoint-up(sm) {
-        //@include qg-link-styles__theme-white($border-radius: $btn-border-radius-base);
-        //text-decoration: none;
-      }
-    }
     & > a:not(.qg-btn) {
       @include media-breakpoint-up(sm) {
         @include qg-link-styles__theme-white;

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -55,8 +55,8 @@
     width: 27.5em;
     .qg-btn:not(.btn-primary) {
       @include media-breakpoint-up(sm) {
-        @include qg-link-styles__theme-white($border-radius: $btn-border-radius-base);
-        text-decoration: none;
+        //@include qg-link-styles__theme-white($border-radius: $btn-border-radius-base);
+        //text-decoration: none;
       }
     }
     & > a:not(.qg-btn) {

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -53,7 +53,7 @@
     margin: 0 15px;
     padding: 1em;
     width: 27.5em;
-    & > a:not(.qg-btn) {
+    & > a:not(.qg-btn):not(.btn) {
       @include media-breakpoint-up(sm) {
         @include qg-link-styles__theme-white;
       }


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/jobs/graduate-portal
Fixing the style of the buttons are made with <a> tag.

Before:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/7c929014-cade-40fb-b02c-8563510b54c8)

After:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/128cc121-5a82-4805-b268-ebbb245af13b)


https://oss-uat.clients.squiz.net/services
Also buttons on service finder don't need the white link mixin. Default sate should not be underlined.
