### PR TITLE
Qoldev 412 dfv visited links

### DIFF
--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -9,8 +9,7 @@
   // make exception for certain classes, which need to re-visit for better optimization
   &:not(.qg-feature-box .qg-link):not(.qg-index a.qg-index-item):not(.page-item
       .page-link):not(.dfv-cards--type-top-prompt
-      a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.qg-aside-button):not(.dfv-back
-      a):not(.QSAR-records-search a):not(.dfv-content a.qg-links-list__link) {
+      a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.qg-aside-button):not(.QSAR-records-search a) {
 
     text-underline-offset: $text-underline-offset;
     // not sure why Asif need to add this, which will have side-effect on customised style added by franchise.

--- a/src/assets/_project/_blocks/components/quick-exit/_qg-quick-exit.scss
+++ b/src/assets/_project/_blocks/components/quick-exit/_qg-quick-exit.scss
@@ -120,6 +120,7 @@
           .qg-quick-exit__tip-link {
             @include qg-underline-on-highlight-decoration;
             @include qg-button-outline-decoration;
+            @include qg-link-styles__theme-white;
             -ms-flex-align: center;
             align-items: center;
             color: white;

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -5,11 +5,12 @@
     color: currentColor;
 }
 .dfv-back a {
-    margin: 0 !important;
+    /*margin: 0 !important;
     border-radius: $btn-border-radius-base !important;
     &:active {
         border-radius: $btn-border-radius-base !important;
-    }
+    }*/
+    text-decoration: none;
 }
 #qg-primary-content .dfv-page-introduction a, #qg-primary-content .dfv-content a:not(.qg-links-list__link) {
     color: $qg-blue-dark !important;

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -6,7 +6,7 @@
 }
 .dfv-back a {
     @include all-states {
-        @include qg-button-outline-decoration;
+        @include qg-button-outline-decoration($btn-border-radius-base);
     }
     margin: 0 !important;
     /*border-radius: $btn-border-radius-base !important;

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -5,6 +5,16 @@
     color: currentColor;
 }
 .dfv-back a {
-    margin: 0;
-    border-radius: $btn-border-radius-base;
+    margin: 0 !important;
+    &:active {
+        border-radius: $btn-border-radius-base;
+    }
+}
+#qg-primary-content .dfv-page-introduction a, #qg-primary-content .dfv-content a {
+    color: $qg-blue-dark !important;
+}
+.dfv-content {
+    a:visited:not(.btn, .button, .qg-btn) {
+        color: currentColor;
+    }
 }

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -5,9 +5,11 @@
     color: currentColor;
 }
 .dfv-back a {
-    @include qg-button-outline-decoration;
-    /*margin: 0 !important;
-    border-radius: $btn-border-radius-base !important;
+    @include all-states {
+        @include qg-button-outline-decoration;
+    }
+    margin: 0 !important;
+    /*border-radius: $btn-border-radius-base !important;
     &:active {
         border-radius: $btn-border-radius-base !important;
     }*/

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -5,10 +5,12 @@
     color: currentColor;
 }
 .dfv-back a {
-    margin: 0 !important;
+    @include qg-button-outline-decoration;
+    /*margin: 0 !important;
+    border-radius: $btn-border-radius-base !important;
     &:active {
         border-radius: $btn-border-radius-base !important;
-    }
+    }*/
 }
 #qg-primary-content .dfv-page-introduction a, #qg-primary-content .dfv-content a:not(.qg-links-list__link) {
     color: $qg-blue-dark !important;

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -5,14 +5,11 @@
     color: currentColor;
 }
 .dfv-back a {
-    @include all-states {
-        @include qg-button-outline-decoration($btn-border-radius-base);
-    }
     margin: 0 !important;
-    /*border-radius: $btn-border-radius-base !important;
+    border-radius: $btn-border-radius-base !important;
     &:active {
         border-radius: $btn-border-radius-base !important;
-    }*/
+    }
 }
 #qg-primary-content .dfv-page-introduction a, #qg-primary-content .dfv-content a:not(.qg-links-list__link) {
     color: $qg-blue-dark !important;

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -1,20 +1,15 @@
 .dfv-content a.qg-links-list__link, .dfv-back a {
     @include qg-link-styles__theme-white;
 }
-.dfv-content a:visited, a.dfv-resource-nav__link {
+.dfv-content a:visited:not(.btn, .button, .qg-btn), a.dfv-resource-nav__link {
     color: currentColor;
 }
 .dfv-back a {
     margin: 0 !important;
     &:active {
-        border-radius: $btn-border-radius-base;
+        border-radius: $btn-border-radius-base !important;
     }
 }
-#qg-primary-content .dfv-page-introduction a, #qg-primary-content .dfv-content a {
+#qg-primary-content .dfv-page-introduction a, #qg-primary-content .dfv-content a:not(.qg-links-list__link) {
     color: $qg-blue-dark !important;
-}
-.dfv-content {
-    a:visited:not(.btn, .button, .qg-btn) {
-        color: currentColor;
-    }
 }

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -1,0 +1,6 @@
+.dfv-content a.qg-links-list__link, .dfv-back a {
+    @include qg-link-styles__theme-white;
+}
+.dfv-content a:visited, a.dfv-resource-nav__link {
+    color: currentColor !important;
+}

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -5,11 +5,6 @@
     color: currentColor;
 }
 .dfv-back a {
-    /*margin: 0 !important;
-    border-radius: $btn-border-radius-base !important;
-    &:active {
-        border-radius: $btn-border-radius-base !important;
-    }*/
     text-decoration: none;
 }
 #qg-primary-content .dfv-page-introduction a, #qg-primary-content .dfv-content a:not(.qg-links-list__link) {

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -1,6 +1,10 @@
 .dfv-content a.qg-links-list__link, .dfv-back a {
     @include qg-link-styles__theme-white;
 }
-/*.dfv-content a:visited, a.dfv-resource-nav__link {
-    color: currentColor !important;
-}*/
+.dfv-content a:visited, a.dfv-resource-nav__link {
+    color: currentColor;
+}
+.dfv-back a {
+    margin: 0;
+    border-radius: $btn-border-radius-base;
+}

--- a/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
+++ b/src/assets/_project/_blocks/franchise/DFV/qg-dfv.scss
@@ -1,6 +1,6 @@
 .dfv-content a.qg-links-list__link, .dfv-back a {
     @include qg-link-styles__theme-white;
 }
-.dfv-content a:visited, a.dfv-resource-nav__link {
+/*.dfv-content a:visited, a.dfv-resource-nav__link {
     color: currentColor !important;
-}
+}*/

--- a/src/assets/_project/_blocks/qg-main.scss
+++ b/src/assets/_project/_blocks/qg-main.scss
@@ -69,6 +69,8 @@
 @import "components/misc/qg-fancybox";
 @import "components/spinners/qg-spinners";
 
+@import "franchise/DFV/qg-dfv";
+
 // QG layout components
 @import "layout/layout-scaffolding"; // Primary layout structure
 

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -321,7 +321,7 @@ $qg-linkedin: #0077b5;
   text-decoration-thickness: 0.5px;
 }
 @mixin qg-link-visited-decoration ($visitedColor: #80b) {
-  &:visited:not([class^="dfv"]):not([class*=' dfv']) {
+  &:visited:not([class^="dfv"]):not([class*=' dfv']):not([class^="dfv"] + span):not([class*=' dfv'] + span) {
     color: $visitedColor;
     text-decoration-color: currentColor;
   }

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -321,7 +321,7 @@ $qg-linkedin: #0077b5;
   text-decoration-thickness: 0.5px;
 }
 @mixin qg-link-visited-decoration ($visitedColor: #80b) {
-  &:visited:not([class^="dfv-"]:not([class*=' dfv'])) {
+  &:visited:not([class^="dfv"]):not([class*=' dfv']) {
     color: $visitedColor;
     text-decoration-color: currentColor;
   }

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -321,7 +321,7 @@ $qg-linkedin: #0077b5;
   text-decoration-thickness: 0.5px;
 }
 @mixin qg-link-visited-decoration ($visitedColor: #80b) {
-  &:visited {
+  &:visited:not([class^="dfv-"]:not([class*=' dfv'])) {
     color: $visitedColor;
     text-decoration-color: currentColor;
   }

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -326,12 +326,6 @@ $qg-linkedin: #0077b5;
     text-decoration-color: currentColor;
   }
 }
-.dfv-content a.qg-links-list__link, .dfv-back a {
-  @include qg-link-styles__theme-white;
-}
-.dfv-content a:visited, a.dfv-resource-nav__link {
-  color: currentColor !important;
-}
 @mixin all-states {
   // Apply styling to all element states, without using !important.
   // This is primarily to help override Bootstrap defaults,

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -326,10 +326,10 @@ $qg-linkedin: #0077b5;
     text-decoration-color: currentColor;
   }
 }
-.dfv-content a.qg-links-list__link, .dfv-back a, a.dfv-resource-nav__link {
+.dfv-content a.qg-links-list__link, .dfv-back a {
   @include qg-link-styles__theme-white;
 }
-.dfv-content a:visited {
+.dfv-content a:visited, a.dfv-resource-nav__link {
   color: currentColor !important;
 }
 @mixin all-states {

--- a/src/assets/_project/_blocks/scss-general/_qg-variables.scss
+++ b/src/assets/_project/_blocks/scss-general/_qg-variables.scss
@@ -321,10 +321,16 @@ $qg-linkedin: #0077b5;
   text-decoration-thickness: 0.5px;
 }
 @mixin qg-link-visited-decoration ($visitedColor: #80b) {
-  &:visited:not([class^="dfv"]):not([class*=' dfv']):not([class^="dfv"] + span):not([class*=' dfv'] + span) {
+  &:visited:not([class^="dfv"]):not([class*=' dfv']) {
     color: $visitedColor;
     text-decoration-color: currentColor;
   }
+}
+.dfv-content a.qg-links-list__link, .dfv-back a, a.dfv-resource-nav__link {
+  @include qg-link-styles__theme-white;
+}
+.dfv-content a:visited {
+  color: currentColor !important;
 }
 @mixin all-states {
   // Apply styling to all element states, without using !important.

--- a/src/assets/_project/_blocks/scss-general/bootstrap/_bridge_bootstrap3.scss
+++ b/src/assets/_project/_blocks/scss-general/bootstrap/_bridge_bootstrap3.scss
@@ -478,6 +478,6 @@ label {
 }
 
 // preserve visited link colour
-a:visited:not(.btn, .button, .qg-btn) {
+a:visited:not(.btn, .button, .qg-btn):not([class^="dfv"]):not([class*=' dfv']) {
   color: #80b;
 }


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/community/getting-support-health-social-issue/support-victims-abuse/domestic-family-violence/what-is-domestic-and-family-violence/what-are-the-patterns-of-domestic-violence/about-domestic-and-family-violence-and-coercive-control
https://oss-uat.clients.squiz.net/community/getting-support-health-social-issue/support-victims-abuse/domestic-family-violence/what-is-domestic-and-family-violence/what-are-the-patterns-of-domestic-violence

This change is to keep the color of the visited links in DFV unchanged for the user's safety reason.
Also #more-information block at the bottom of first link and Back button on the top left corner of DFV subpages were missing the standard SWE link and button styles. They now have.

Not all DFV pages have the class .dvf-content. So there are different links that need to be addressed, like the links in the side nav, the links in the content body, the link lists.

Improvements:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/0167008d-967d-4398-bb90-308011f76469)

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/163114a9-572a-43a7-89f5-d6b586b45870)

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/f1822b2a-1d52-483e-a987-2e4354d222c4)

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/27b324b5-f216-4a54-8d42-9739d0a4f334)

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/cac053be-09a7-4bb1-b19c-3fcb4d810a9a)
