### PR TITLE
Qoldev 416 top margin for pages

### DIFF
--- a/src/assets/_project/_blocks/components/print/qg-print.scss
+++ b/src/assets/_project/_blocks/components/print/qg-print.scss
@@ -1,6 +1,6 @@
 // page options including print and subscribe buttons
 #qg-page-options {
-  margin-bottom: 20px;
+  margin-bottom: 15px;
   display: flex;
   justify-content: end;
   column-gap: 1rem;

--- a/src/assets/_project/_blocks/components/print/qg-print.scss
+++ b/src/assets/_project/_blocks/components/print/qg-print.scss
@@ -1,7 +1,6 @@
 // page options including print and subscribe buttons
 #qg-page-options {
   margin-bottom: 20px;
-  height: 30px;
   display: flex;
   justify-content: end;
   column-gap: 1rem;

--- a/src/assets/_project/_blocks/layout/footer/_site-footer.scss
+++ b/src/assets/_project/_blocks/layout/footer/_site-footer.scss
@@ -7,7 +7,7 @@
         padding: 0;
     }
 
-    a:not(.btn):not(.qg-footer-feedback__close):not(#qg-forms__validation-errors a) {
+    a:not(.btn):not(#qg-footer-feedback a) {
       @include qg-link-styles__theme-white;
     }
     #qg-footer-feedback a:not(.btn) {


### PR DESCRIPTION
Removing fixed height from page options to remove the vertical space added to all pages.
Example:
without page options: https://oss-uat.clients.squiz.net/transport
with page options: https://uat.forgov.qld.gov.au/information-and-communication-technology/qgea-policies-standards-and-guidelines/principles-for-the-use-of-service-delivery-channels

Also excluding white link from the form inside the feedback form.