### PR TITLE
QOLDEV-321 Making print link absolute

### DIFF
--- a/src/assets/_project/_blocks/components/print/qg-print.scss
+++ b/src/assets/_project/_blocks/components/print/qg-print.scss
@@ -1,7 +1,14 @@
 // print button styles
-.print-content-link{
-  position: absolute;
-  right: 35px;
-  z-index:1;
-  top: -28px;
+#qg-page-options {
+  a {
+    position: absolute;
+    z-index: 1;
+    top: -40px;
+  }
+  .fg-subscribe__link {
+    right: -110px;
+  }
+  .print-content-link {
+    right: 35px;
+  }
 }

--- a/src/assets/_project/_blocks/components/print/qg-print.scss
+++ b/src/assets/_project/_blocks/components/print/qg-print.scss
@@ -1,7 +1,7 @@
-// page options including print and subscribe buttons
-#qg-page-options {
-  margin-bottom: 15px;
-  display: flex;
-  justify-content: end;
-  column-gap: 1rem;
+// print button styles
+.print-content-link{
+  position: absolute;
+  right: 35px;
+  z-index:1;
+  top: -28px;
 }

--- a/src/assets/_project/_blocks/components/print/qg-print.scss
+++ b/src/assets/_project/_blocks/components/print/qg-print.scss
@@ -1,4 +1,4 @@
-// print button styles
+// page options including print and subscribe buttons
 #qg-page-options {
   position: absolute;
   top: -40px;
@@ -8,6 +8,6 @@
     position: relative;
     top: initial;
     right: initial;
-    margin-left: 1rem;
+    margin-left: 1rem !important;
   }
 }

--- a/src/assets/_project/_blocks/components/print/qg-print.scss
+++ b/src/assets/_project/_blocks/components/print/qg-print.scss
@@ -1,14 +1,13 @@
 // print button styles
 #qg-page-options {
+  position: absolute;
+  top: -40px;
+  right: 35px;
+  z-index: 1;
   a {
-    position: absolute;
-    z-index: 1;
-    top: -40px;
-  }
-  .fg-subscribe__link {
-    right: -110px;
-  }
-  .print-content-link {
-    right: 35px;
+    position: relative;
+    top: initial;
+    right: initial;
+    margin-left: 1rem;
   }
 }

--- a/src/assets/_project/_blocks/layout/section-nav/_mobile_step_nav.scss
+++ b/src/assets/_project/_blocks/layout/section-nav/_mobile_step_nav.scss
@@ -24,7 +24,7 @@
       margin: 0;
       padding: 0;
       a {
-        color: white;
+        color: white !important;
       }
       ol.guide-sub-nav {
         list-style: none;


### PR DESCRIPTION
After talking to Bec and Manjeet, page options is updated to avoid the impact on the vertical spacing at the top of the pages.
Examples:
https://uat.forgov.qld.gov.au/information-and-communication-technology/qgea-policies-standards-and-guidelines/principles-for-the-use-of-service-delivery-channels
https://oss-uat.clients.squiz.net/environment/plants-animals/wildlife-permits/permit-types/recreational

Also fixing an obvious a11y bug on the second link.

Before:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/1ed7153c-22fc-4a67-b70f-f6c9925426a7)
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/e349ceee-f35d-4784-99d7-d4745b6d3e87)

After:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/291f8c2f-f919-4d21-87c8-2c69b7aabef1)
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/1a6b6b69-a6b3-4735-8e8b-dd1e5a83fed5)

