### PR TITLE
QOLDEV-430 Removing visited links style from _bridge-bootstrap3

### DIFF
--- a/src/assets/_project/_blocks/scss-general/bootstrap/_bridge_bootstrap3.scss
+++ b/src/assets/_project/_blocks/scss-general/bootstrap/_bridge_bootstrap3.scss
@@ -477,7 +477,3 @@ label {
   font-weight: 700;
 }
 
-// preserve visited link colour
-a:visited:not(.btn, .button, .qg-btn):not(.qg-private-content a):not([class^="dfv"]):not([class*=' dfv']) {
-  color: #80b;
-}


### PR DESCRIPTION
https://ssq-qol.atlassian.net/browse/QOLDEV-430
This is to remove the visited link styles from unwanted spots like menu items, search suggestions, header links.

The visited link style is already covered by qg-link-visited-decoration mixin when needed.

This branch is deployed to UAT for the time being.

Before:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/1e01759e-0421-4847-b5e9-2e8522d627fb)

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/19e9f225-46be-463e-a636-f4ea28c8d0e2)
