### PR TITLE
QOLDEV-67 and QOLSVC-2024 carousel improvements

### DIFF
--- a/src/assets/_project/_blocks/components/carousel/_qg-carousel.scss
+++ b/src/assets/_project/_blocks/components/carousel/_qg-carousel.scss
@@ -123,11 +123,14 @@
           position: initial;
           left: inherit;
           top: 0;
-          width: inherit;
           right: 0;
+          width: inherit;
+          
           background-image: none;
           color: #000;
           text-shadow: none;
+          margin : 0 !important;
+
           .icon-prev,.icon-next{
             position: inherit;
           }


### PR DESCRIPTION
Applied a specific 0px margin rule for carousel control buttons to overcome an inherited 2px margin.

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438309/81059561-1b46-4558-967c-eab6ee123339)
