### PR TITLE
QOLDEV 67 carousel margins new PR

### DIFF
--- a/src/assets/_project/_blocks/components/carousel/_qg-carousel.scss
+++ b/src/assets/_project/_blocks/components/carousel/_qg-carousel.scss
@@ -123,8 +123,9 @@
           position: initial;
           left: inherit;
           top: 0;
-          width: inherit;
           right: 0;
+          width: inherit;
+          margin: 0 !important;
           background-image: none;
           color: #000;
           text-shadow: none;


### PR DESCRIPTION
New 0px margins applied to carousel control buttons to overcome an inherited 2px margin that was added to a global scope.

!important tag used due to very narrow scope of this carousel control class. 