### PR TITLE
QOLDEV-431 Displaying only the direct parent page in the breadcrumb f…

### DIFF
--- a/src/assets/_project/_blocks/layout/breadcrumbs/_breadcrumbs.scss
+++ b/src/assets/_project/_blocks/layout/breadcrumbs/_breadcrumbs.scss
@@ -31,16 +31,16 @@
             }
 
             &.shortened {
-        height: 0;
+                height: 0;
                 overflow: hidden;
                 max-width: 0;
                 transition: max-width 0s;
             }
 
             .qg-breadcrumb-list-item__link {
-        color: #292929;
-        @include qg-link-styles__theme-black-always;
-      }
+                color: #292929;
+                @include qg-link-styles__theme-black-always;
+            }
 
             &:last-child {
                 &:after {
@@ -59,7 +59,7 @@
 }
 
 @include media-breakpoint-down(sm) {
-    .qg-breadcrumb-list-item {
+    #qg-breadcrumb .qg-breadcrumb-list-item {
         display: none;
 
         &:nth-last-child(2) {


### PR DESCRIPTION
…on small devices

Only the direct parent should be displayed in the breadcrumb for screens smaller than 991.

Example: [Getting some help](https://www.qld.gov.au/disability/adults/getting-help) 

UAT is updated with this change.

Before:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/257c6fe0-fad8-4522-b8e8-42a8d57bee3f)

After:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/dc322cdc-3d02-4c9c-bed6-24ccbf9ef358)
