### PR TITLE
QOLDEV-428 accordion button hover state hotfix

### DIFF
--- a/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
+++ b/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
@@ -1,31 +1,48 @@
 .qg-accordion {
-  &.qg-accordion-v2{
-    article{
+  &.qg-accordion-v2 {
+    article {
       border: 1px solid gray;
+
       &:last-child {
         border-bottom: 1px solid gray !important;
       }
-      & + article{
-        border-top:none;
+
+      &+article {
+        border-top: none;
       }
+
       .collapsing-section {
         border-top: 1px solid gray;
         padding: 1rem;
+
         & *:first-child {
           margin-top: 0;
         }
+
         & *:last-child {
           margin-bottom: 0;
         }
       }
-      .acc-heading{
+      
+      .acc-heading {
+
         padding: 1rem;
+
+        &:hover > a, 
+        &:focus > a,
+        &:focus-visible > a
+        {
+          text-decoration-thickness: 2px !important;
+        }
+
+
         .title {
           color: $qg-blue-dark;
           text-decoration-line: underline;
           font-weight: bold;
           padding-right: 1.8rem;
         }
+
         .qg-accordion--ga:after {
           content: ' ';
           position: absolute;
@@ -40,21 +57,26 @@
           z-index: 101;
           transition: transform 0.25s ease-in;
         }
+
         .accordion-label {
           display: inline-block;
         }
-        img + .accordion-label{
+
+        img+.accordion-label {
           margin-left: 2.5rem;
           margin-bottom: 0;
         }
       }
-      .qg-accordion--open .qg-accordion--ga:after{
+
+      .qg-accordion--open .qg-accordion--ga:after {
         transform: rotate(0deg);
       }
-      .qg-accordion--closed .qg-accordion--ga:after{
+
+      .qg-accordion--closed .qg-accordion--ga:after {
         transform: rotate(-180deg);
       }
-      .qg-accordion--open + .collapsing-section {
+
+      .qg-accordion--open+.collapsing-section {
         display: block;
         visibility: inherit;
         opacity: inherit;
@@ -62,71 +84,92 @@
       }
     }
   }
+
   button {
     @include qg-button-outline-decoration ($margin: 0px) {
       z-index: 100;
     }
   }
+
   &.qg-dark-accordion article {
     background-color: #f5f5f5;
   }
-  .qg-acc-controls{
+
+  .qg-acc-controls {
     text-align: right;
     margin-bottom: 0.4em;
-    button{
+
+    button {
       border: none;
       background: none;
       color: $qg-blue-dark !important;
       font-weight: 700;
     }
-    a{
+
+    a {
       text-decoration-line: none !important;
       padding: 0.4rem 0.7rem;
       @include qg-link-unvisited-color($qg-blue-dark !important);
       font-weight: bold;
       display: inline-block;
     }
+
     .collapse:not(.show) {
       display: inline;
     }
   }
+
   //label selector is to provide backward compatibility in case projects are using old markup
-  label[for="expand"], label[for="collapse"] {
+  label[for="expand"],
+  label[for="collapse"] {
     text-decoration-line: none !important;
     padding: 0 0.7rem;
     color: $qg-blue-dark !important;
     font-weight: bold;
     display: inline-block;
   }
-  .expand, .collapse, label[for="expand"], label[for="collapse"] {
-    &:hover, &.hover {
+
+  .expand,
+  .collapse,
+  label[for="expand"],
+  label[for="collapse"] {
+
+    &:hover,
+    &.hover {
       text-decoration-line: underline !important;
     }
   }
-  .ht{
+
+  .ht {
     text-decoration-line: underline;
   }
+
   article {
     position: relative;
     width: 100%;
     color: $black;
     border-bottom: 1px solid #dedede;
+
     &:last-child {
       border-bottom: none;
     }
+
     .acc-heading {
       position: relative;
       padding: 0.6rem 0.7rem;
       width: 100%;
       background: transparent;
-      border:none;
-      text-align:left;
-      .title{
+      border: none;
+      text-align: left;
+
+      .title {
         display: block;
+
         &:hover {
           text-decoration-line: underline;
         }
       }
+
       label {
         position: relative;
         display: block;
@@ -138,30 +181,36 @@
         padding-right: 2rem;
         margin-bottom: 0;
       }
-      img, .fa {
+
+      img,
+      .fa {
         position: absolute;
         top: 50%;
         transform: translateY(-50%);
         right: 0;
         left: 1rem;
-        + label{
+
+        +label {
           padding-left: 2.7rem;
         }
       }
+
       img {
         width: 1.8em;
         height: auto;
       }
+
       .subtitle {
         @include rem(font-size, 16px);
         font-weight: 400;
         display: block;
         margin-top: 0.3rem;
         color: #000;
-        margin-right:1rem;
+        margin-right: 1rem;
       }
     }
   }
+
   .collapsing-section {
     background: white;
     max-height: 0;
@@ -172,29 +221,36 @@
     border: 0;
     padding: 1rem 2.5rem;
     display: none;
+
     p {
       margin-top: 0 !important;
     }
   }
-  input[name=tabs],input[name=control] {
+
+  input[name=tabs],
+  input[name=control] {
     position: absolute;
     opacity: 0;
     z-index: -1;
-    &:checked ~ .collapsing-section {
+
+    &:checked~.collapsing-section {
       max-height: inherit;
       visibility: visible;
       opacity: 1;
       transition: visibility 0s linear 0s, opacity 900ms;
       display: block;
     }
-    &[type=checkbox]:checked + .acc-heading label i {
+
+    &[type=checkbox]:checked+.acc-heading label i {
       transform: rotate(-135deg);
       -webkit-transform: rotate(-135deg);
     }
-    &[type=checkbox]:checked + .acc-heading .title{
+
+    &[type=checkbox]:checked+.acc-heading .title {
       text-decoration-line: underline;
     }
-    &.expand:checked ~ article {
+
+    &.expand:checked~article {
       .collapsing-section {
         max-height: inherit;
         visibility: visible;
@@ -203,11 +259,13 @@
       }
     }
   }
+
   .arrow {
     position: absolute;
     top: 34%;
     line-height: 0;
     right: 8px;
+
     i {
       border: solid #007EB1;
       border-width: 0 3px 3px 0;
@@ -218,6 +276,7 @@
     }
   }
 }
+
 @media screen and (max-width: 640px) {
   .qg-accordion .acc-heading {
     font-size: 1em;
@@ -226,11 +285,20 @@
 
 // IOS safari specific styles
 @media not all and (min-resolution:.001dpcm) {
-  .qg-accordion .acc-heading:focus, .qg-accordion .acc-heading.focus {
+
+  .qg-accordion .acc-heading:focus,
+  .qg-accordion .acc-heading.focus {
     outline: 2px solid $qg-blue;
   }
-  .qg-accordion .expand:focus, .qg-accordion .expand:active, .qg-accordion .collapse:focus, .qg-accordion .collapse:active,
-  .qg-accordion .expand.focus, .qg-accordion .expand.active, .qg-accordion .collapse.focus, .qg-accordion .collapse.active {
+
+  .qg-accordion .expand:focus,
+  .qg-accordion .expand:active,
+  .qg-accordion .collapse:focus,
+  .qg-accordion .collapse:active,
+  .qg-accordion .expand.focus,
+  .qg-accordion .expand.active,
+  .qg-accordion .collapse.focus,
+  .qg-accordion .collapse.active {
     outline: 2px solid $qg-blue !important;
     outline-offset: -2px;
   }


### PR DESCRIPTION
A _button:hover > a_ state was required to replicate the behaviour of a direct a:hover state.

Button hovers should apply to full width (and height) of accordion headings. 