### PR TITLE
Qoldev 427 links within alerts

### DIFF
--- a/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
+++ b/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
@@ -24,6 +24,10 @@
     @include qg-global-link-styles {
       @include qg-link-decoration;
     }
+    &:hover {
+      text-decoration-thickness: 2px !important;
+      color: $qg-blue-dark;
+    }
   }
   & + p{
     margin-top: 1em;


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/jobs/jobs-and-training-support/help-starting/help-looking-for-work

Link should not change color when visited or hovered. Underline thickness should change when hovered.

UAT is updated with this change.

Expected hover state:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/c9e461e6-3c7a-45c5-8591-a0d69f3c7072)
