### PR TITLE
QOLDEV-74 Improving <figure> styles

### DIFF
--- a/src/assets/_project/_blocks/components/misc/_qg-images.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-images.scss
@@ -5,7 +5,7 @@
 // figures / cut ins
 
 #qg-primary-content figure:not(.qg-nofig), figure.qg-fig {
-  max-width: 300px !important;
+  max-width: 300px;
   max-height: auto !important;
 
   margin-left: auto;
@@ -14,7 +14,7 @@
   text-align: center;
 
   @media (max-width: $screen-md) {
-    max-width: 374px !important;
+    max-width: 374px;
   }
 
   &:not(.qg-unstyled) {
@@ -33,6 +33,10 @@
     &+figure {
       clear: left;
     }
+  }
+
+  &.max-width-none {
+    max-width: none;
   }
 
   img {


### PR DESCRIPTION
- removing important from max-width for figure to able to override it via the new full-width configuration in image content container template (asset 821)
- defining max-width-none class to be used in image cct when it is configured to be full-width