### PR TITLE
QOLDEV-352 Applying dark theme colors (white) to the links within banner

### DIFF
--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -53,7 +53,7 @@
     margin: 0 15px;
     padding: 1em;
     width: 27.5em;
-    & > a:not(.qg-btn):not(.btn) {
+    a:not(.qg-btn):not(.btn) {
       @include media-breakpoint-up(sm) {
         @include qg-link-styles__theme-white;
       }


### PR DESCRIPTION
It was only working for links that directly come after .blurb class. In example below link is inside p.

Before:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/2e42eb08-5439-4447-b85b-97c86db1e04a)

After:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/795777b6-d5a1-4da1-b6b5-4302a19f8608)
