### PR TITLE
QOLDEV-443 Replacing no-print with bootstrap d-print-none

### DIFF
--- a/src/docs/examples/breadcrumb.html
+++ b/src/docs/examples/breadcrumb.html
@@ -856,15 +856,15 @@
     </div>
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a href="https://www.qld.gov.au/help" class="no-print">Help</a></li>
+        <li><a href="https://www.qld.gov.au/help" class="d-print-none">Help</a></li>
         <li><a href="https://www.qld.gov.au/legal/copyright">Copyright</a></li>
         <li><a href="https://www.qld.gov.au/legal/disclaimer">Disclaimer</a></li>
         <li><a href="https://www.qld.gov.au/legal/privacy">Privacy</a></li>
         <li><a href="https://www.qld.gov.au/about/rights-accountability/right-to-information">Right to information</a></li>
-        <li><a href="https://www.qld.gov.au/help/accessibility" class="no-print">Accessibility</a></li>
+        <li><a href="https://www.qld.gov.au/help/accessibility" class="d-print-none">Accessibility</a></li>
         <li class="d-none"><a href="https://www.qld.gov.au/help/keyboard" accesskey="0">Keyboard Accessibility</a>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="no-print">Other languages</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-yearrange">1995&ndash;2021</span></p>
     </div>

--- a/src/docs/examples/cut-in.html
+++ b/src/docs/examples/cut-in.html
@@ -1107,15 +1107,15 @@
     </div>
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a href="https://www.qld.gov.au/help" class="no-print">Help</a></li>
+        <li><a href="https://www.qld.gov.au/help" class="d-print-none">Help</a></li>
         <li><a href="https://www.qld.gov.au/legal/copyright">Copyright</a></li>
         <li><a href="https://www.qld.gov.au/legal/disclaimer">Disclaimer</a></li>
         <li><a href="https://www.qld.gov.au/legal/privacy">Privacy</a></li>
         <li><a href="https://www.qld.gov.au/about/rights-accountability/right-to-information">Right to information</a></li>
-        <li><a href="https://www.qld.gov.au/help/accessibility" class="no-print">Accessibility</a></li>
+        <li><a href="https://www.qld.gov.au/help/accessibility" class="d-print-none">Accessibility</a></li>
         <li class="d-none"><a href="https://www.qld.gov.au/help/keyboard" accesskey="0">Keyboard Accessibility</a>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="no-print">Other languages</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-yearrange">1995&ndash;2021</span></p>
     </div>

--- a/src/docs/examples/form-new-styles.html
+++ b/src/docs/examples/form-new-styles.html
@@ -1539,15 +1539,15 @@
     </div>
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a href="https://oss-uat.clients.squiz.net/help" class="no-print">Help</a></li>
+        <li><a href="https://oss-uat.clients.squiz.net/help" class="d-print-none">Help</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/legal/copyright">Copyright</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/legal/disclaimer">Disclaimer</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/legal/privacy">Privacy</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/about/rights-accountability/right-to-information">Right to information</a></li>
-        <li><a href="https://oss-uat.clients.squiz.net/help/accessibility" class="no-print">Accessibility</a></li>
+        <li><a href="https://oss-uat.clients.squiz.net/help/accessibility" class="d-print-none">Accessibility</a></li>
         <li class="d-none"><a href="https://oss-uat.clients.squiz.net/help/keyboard" accesskey="0">Keyboard Accessibility</a>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://oss-uat.clients.squiz.net/help/languages" class="no-print">Other languages</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://oss-uat.clients.squiz.net/help/languages" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-yearrange">1995&ndash;2022</span></p>
     </div>

--- a/src/docs/examples/formio.html
+++ b/src/docs/examples/formio.html
@@ -1012,15 +1012,15 @@
     </div>
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a href="https://oss-uat.clients.squiz.net/help" class="no-print">Help</a></li>
+        <li><a href="https://oss-uat.clients.squiz.net/help" class="d-print-none">Help</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/legal/copyright">Copyright</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/legal/disclaimer">Disclaimer</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/legal/privacy">Privacy</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/about/rights-accountability/right-to-information">Right to information</a></li>
-        <li><a href="https://oss-uat.clients.squiz.net/help/accessibility" class="no-print">Accessibility</a></li>
+        <li><a href="https://oss-uat.clients.squiz.net/help/accessibility" class="d-print-none">Accessibility</a></li>
         <li class="d-none"><a href="https://oss-uat.clients.squiz.net/help/keyboard" accesskey="0">Keyboard Accessibility</a>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://oss-uat.clients.squiz.net/help/languages" class="no-print">Other languages</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://oss-uat.clients.squiz.net/help/languages" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-yearrange">1995&ndash;2022</span></p>
     </div>

--- a/src/docs/examples/guide-page.html
+++ b/src/docs/examples/guide-page.html
@@ -740,15 +740,15 @@
     </div>
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a href="https://www.qld.gov.au/help" class="no-print">Help</a></li>
+        <li><a href="https://www.qld.gov.au/help" class="d-print-none">Help</a></li>
         <li><a href="https://www.qld.gov.au/legal/copyright">Copyright</a></li>
         <li><a href="https://www.qld.gov.au/legal/disclaimer">Disclaimer</a></li>
         <li><a href="https://www.qld.gov.au/legal/privacy">Privacy</a></li>
         <li><a href="https://www.qld.gov.au/about/rights-accountability/right-to-information">Right to information</a></li>
-        <li><a href="https://www.qld.gov.au/help/accessibility" class="no-print">Accessibility</a></li>
+        <li><a href="https://www.qld.gov.au/help/accessibility" class="d-print-none">Accessibility</a></li>
         <li class="d-none"><a href="https://www.qld.gov.au/help/keyboard" accesskey="0">Keyboard Accessibility</a>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="no-print">Other languages</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-yearrange">1995&ndash;2021</span></p>
     </div>

--- a/src/docs/examples/index.html
+++ b/src/docs/examples/index.html
@@ -562,14 +562,14 @@
 
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a href="https://www.qld.gov.au/help/" class="no-print">Help</a></li>
+        <li><a href="https://www.qld.gov.au/help/" class="d-print-none">Help</a></li>
         <li><a href="https://www.qld.gov.au/legal/copyright/">Copyright</a></li>
         <li><a href="https://www.qld.gov.au/legal/disclaimer/">Disclaimer</a></li>
         <li><a href="https://www.qld.gov.au/legal/privacy/">Privacy</a></li>
         <li><a href="https://www.qld.gov.au/right-to-information/">Right to information</a></li>
-        <li><a href="https://www.qld.gov.au/help/accessibility/" class="no-print">Accessibility</a></li>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://www.qld.gov.au/languages/" class="no-print">Other languages</a></li>
+        <li><a href="https://www.qld.gov.au/help/accessibility/" class="d-print-none">Accessibility</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://www.qld.gov.au/languages/" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-daterange"></span></p>
     </div>

--- a/src/docs/examples/recaptcha2.html
+++ b/src/docs/examples/recaptcha2.html
@@ -1334,15 +1334,15 @@
     </div>
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a href="https://www.qld.gov.au/help" class="no-print">Help</a></li>
+        <li><a href="https://www.qld.gov.au/help" class="d-print-none">Help</a></li>
         <li><a href="https://www.qld.gov.au/legal/copyright">Copyright</a></li>
         <li><a href="https://www.qld.gov.au/legal/disclaimer">Disclaimer</a></li>
         <li><a href="https://www.qld.gov.au/legal/privacy">Privacy</a></li>
         <li><a href="https://www.qld.gov.au/about/rights-accountability/right-to-information">Right to information</a></li>
-        <li><a href="https://www.qld.gov.au/help/accessibility" class="no-print">Accessibility</a></li>
+        <li><a href="https://www.qld.gov.au/help/accessibility" class="d-print-none">Accessibility</a></li>
         <li class="d-none"><a href="https://www.qld.gov.au/help/keyboard" accesskey="0">Keyboard Accessibility</a>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="no-print">Other languages</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-yearrange">1995&ndash;2021</span></p>
     </div>

--- a/src/docs/examples/search-page.html
+++ b/src/docs/examples/search-page.html
@@ -1077,15 +1077,15 @@
     </div>
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a href="https://www.qld.gov.au/help" class="no-print">Help</a></li>
+        <li><a href="https://www.qld.gov.au/help" class="d-print-none">Help</a></li>
         <li><a href="https://www.qld.gov.au/legal/copyright">Copyright</a></li>
         <li><a href="https://www.qld.gov.au/legal/disclaimer">Disclaimer</a></li>
         <li><a href="https://www.qld.gov.au/legal/privacy">Privacy</a></li>
         <li><a href="https://www.qld.gov.au/about/rights-accountability/right-to-information">Right to information</a></li>
-        <li><a href="https://www.qld.gov.au/help/accessibility" class="no-print">Accessibility</a></li>
+        <li><a href="https://www.qld.gov.au/help/accessibility" class="d-print-none">Accessibility</a></li>
         <li class="d-none"><a href="https://www.qld.gov.au/help/keyboard" accesskey="0">Keyboard Accessibility</a>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="no-print">Other languages</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-yearrange">1995&ndash;2021</span></p>
     </div>

--- a/src/docs/examples/section-nav-example.html
+++ b/src/docs/examples/section-nav-example.html
@@ -826,14 +826,14 @@
     </div>
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a accesskey="0" href="https://www.qld.gov.au/help" class="no-print">Help</a></li>
+        <li><a accesskey="0" href="https://www.qld.gov.au/help" class="d-print-none">Help</a></li>
         <li><a href="https://www.qld.gov.au/legal/copyright">Copyright</a></li>
         <li><a href="https://www.qld.gov.au/legal/disclaimer">Disclaimer</a></li>
         <li><a href="https://www.qld.gov.au/legal/privacy">Privacy</a></li>
         <li><a href="https://www.qld.gov.au/about/rights-accountability/right-to-information">Right to information</a></li>
-        <li><a href="https://www.qld.gov.au/help/accessibility" class="no-print">Accessibility</a></li>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="no-print">Other languages</a></li>
+        <li><a href="https://www.qld.gov.au/help/accessibility" class="d-print-none">Accessibility</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://www.qld.gov.au/help/languages" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-yearrange">1995&ndash;2021</span></p>
     </div>

--- a/src/docs/examples/service-finder.html
+++ b/src/docs/examples/service-finder.html
@@ -1214,15 +1214,15 @@
     </div>
     <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
       <ul class="list-inline col-lg-6 col-md-6">
-        <li><a href="https://oss-uat.clients.squiz.net/help" class="no-print">Help</a></li>
+        <li><a href="https://oss-uat.clients.squiz.net/help" class="d-print-none">Help</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/legal/copyright">Copyright</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/legal/disclaimer">Disclaimer</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/legal/privacy">Privacy</a></li>
         <li><a href="https://oss-uat.clients.squiz.net/about/rights-accountability/right-to-information">Right to information</a></li>
-        <li><a href="https://oss-uat.clients.squiz.net/help/accessibility" class="no-print">Accessibility</a></li>
+        <li><a href="https://oss-uat.clients.squiz.net/help/accessibility" class="d-print-none">Accessibility</a></li>
         <li class="d-none"><a href="https://oss-uat.clients.squiz.net/help/keyboard" accesskey="0">Keyboard Accessibility</a>
-        <li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-        <li id="link-languages"><a href="https://oss-uat.clients.squiz.net/help/languages" class="no-print">Other languages</a></li>
+        <li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+        <li id="link-languages"><a href="https://oss-uat.clients.squiz.net/help/languages" class="d-print-none">Other languages</a></li>
       </ul>
       <p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-yearrange">1995&ndash;2021</span></p>
     </div>


### PR DESCRIPTION
https://getbootstrap.com/docs/5.0/utilities/display/#display-in-print
Replacing no-print with Bootstrap d-print-none which is available in Bootstrap 4 and 5.
d-print-none is going to be added in the global page layout to hide page options containing forgov subscrive link.

https://uat.forgov.qld.gov.au/information-and-communication-technology/qgea-policies-standards-and-guidelines/principles-for-the-use-of-service-delivery-channels#

**Before:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/bcdd4cf8-ad16-49d1-89b1-dd14c84ad70e)


**After:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/94dad7f0-40ab-4bf9-8222-5627d782aa93)
