### PR TITLE
Qoldev 73 striped tables

### DIFF
--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -246,7 +246,7 @@ table.dataTable {
   float: right;
   text-align: right;
   padding: 0.5em 0;
-  .previous, .next {
+  .previous:before, .next:after {
     display: inline-block;
   }
 }

--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -39,9 +39,9 @@
         padding: 1em;
       }
     }
-  }
-  &.qg-table-no-striped tr {
-    background: white;
+    &.qg-table-no-striped tr {
+      background: white;
+    }
   }
 }
 

--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -240,6 +240,9 @@ table.dataTable {
   float: right;
   text-align: right;
   padding: 0.5em 0;
+  .previous, .next {
+    display: inline-block;
+  }
 }
 
 /* Two button pagination - previous / next */

--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -31,11 +31,17 @@
       }
     }
     tr {
+      background: #f6f6f6;
+      &:nth-child(even) {
+        background: white;
+      }
       td {
         padding: 1em;
       }
     }
-
+  }
+  &.qg-table-no-striped tr {
+    background: white;
   }
 }
 

--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -24,6 +24,7 @@
     font-weight: bold;
   }
   table {
+    @extend .table; // inheriting bootstrap table styles
     thead {
       tr {
         background-color: #005375;

--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -31,10 +31,6 @@
       }
     }
     tr {
-      background: #f6f6f6;
-      &:nth-child(even) {
-        background: white;
-      }
       td {
         padding: 1em;
       }

--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -39,8 +39,11 @@
         padding: 1em;
       }
     }
-    &.qg-table-no-striped tr {
-      background: white;
+    &.qg-table-no-striped {
+      @extend .table-bordered;
+      tr {
+        background: white;
+      }
     }
   }
 }

--- a/src/stories/components/Table/Table.stories.mdx
+++ b/src/stories/components/Table/Table.stories.mdx
@@ -4,6 +4,7 @@ import { QgPrimaryContent, QgContent } from "../../decorators";
 import { getDecoratedParameters } from "../../helpers";
 
 import Default from "./templates/Default.html";
+import NoStripe from "./templates/NoStripe.html";
 
 <Meta title="Components/Table" decorators={[QgPrimaryContent, QgContent]} />
 
@@ -16,5 +17,13 @@ Requires `#QgPrimaryContent` ancestor.
 <Canvas withSource="open">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
+  </Story>
+</Canvas>
+
+## NoStripe
+
+<Canvas withSource="open">
+  <Story name="NoStripe" parameters={getDecoratedParameters(NoStripe)}>
+    {() => NoStripe}
   </Story>
 </Canvas>

--- a/src/stories/components/Table/templates/NoStripe.html
+++ b/src/stories/components/Table/templates/NoStripe.html
@@ -1,0 +1,44 @@
+<!--
+Row header:  <th class="scope="row">
+Column header:  <th class="scope="col">
+-->
+
+<table class="table qg-table-no-striped">
+    <caption>
+      Table caption
+    </caption>
+    <thead>
+      <tr>
+        <th scope="col">Header</th>
+        <th scope="col">Header</th>
+        <th scope="col">Header</th>
+        <th scope="col" class="text-right">Header</th>
+        <th scope="col" class="text-right">Header</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td class="text-right">7,670,700</td>
+        <td class="text-right">3.1%</td>
+      </tr>
+  
+      <tr>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td class="text-right">5,996,400</td>
+        <td class="text-right">2.5%</td>
+      </tr>
+      <tr>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td>Cell</td>
+        <td class="text-right">517,400</td>
+        <td class="text-right">4.0%</td>
+      </tr>
+    </tbody>
+  </table>
+  


### PR DESCRIPTION
https://uat.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/table

https://oss-uat.clients.squiz.net/dev/ghazal/test-table

SWE tables are striped by default.
This change was originated from a service request to add a SWE class to remove tiger stripes from the tables and also making them bordered at the same time for visibility.

Class qg-table-no-striped is defined to do that. Also I made <table> to inherit bootstrap `table `class. This makes the tables full-width.

**Before:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/792ecfa2-b8c5-45b4-8990-4f71bbf488d9)

**After:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/3ffa7288-3409-466b-a2be-d42813889e5b)

The same result is possible by adding customised classes in [global design customisation](https://oss-uat.clients.squiz.net/_admin/?screen=styles&assetid=118372) to apply bootstrap classes like `table-bordered`, `table-borderless`, `table-striped`.

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/e7e8cad4-242d-41b2-82e9-03e47230afbf)

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/2f44cb70-fd1e-437a-859a-1e1377e4c628)

Also fixing the icons in the Prev/Next buttons for sortable tables.
https://oss-uat.clients.squiz.net/_resources/matrix-documentation/components/searchable-and-sortable-table

Before:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/8b750902-9218-4351-a381-d472d9e38581)

After:
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/ffac6cf2-5c49-4cd7-9e4e-3a99a61f5d90)

Sorted table still needs to be improved. It is not a standard SWE component yet.