### PR TITLE
QOLDEV-450 Styling the buttons within alertbox

### DIFF
--- a/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
+++ b/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
@@ -20,7 +20,7 @@
     margin-top: 5px;
     font-size: 1.2em;
   }
-  a {
+  a:not(.btn, .qg-btn) {
     @include qg-global-link-styles {
       @include qg-link-decoration;
     }
@@ -29,7 +29,7 @@
       color: $qg-blue-dark;
     }
   }
-  & + p{
+  & + p {
     margin-top: 1em;
   }
   &.alert-danger {


### PR DESCRIPTION
Buttons within alertboxes should not have underline in default state
https://oss-uat.clients.squiz.net/housing/buying-owning-home/financial-help-concessions/resilient-homes-fund
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/785ec66f-a1f7-42f4-9e0c-897858dce581)

