### PR TITLE
QOLDEV-74 Using the correct class for images without border

### DIFF
--- a/src/stories/components/Images/templates/WithoutBorder.html
+++ b/src/stories/components/Images/templates/WithoutBorder.html
@@ -1,4 +1,4 @@
-<figure class="unstyled">
+<figure class="qg-unstyled">
   <img src="https://static.qgov.net.au/assets/v4/latest/images/placeholders/SWE-image-example.jpg" alt="Example figure image with no border" />
   <figcaption>
     Wheel of Brisbane at South Bank


### PR DESCRIPTION
https://qld-gov-au.github.io/qg-web-template/?path=/story/components-images--without-border
**Before:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/88961405-62d3-498c-9533-a9c4ad3d01d0)

**After:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/2c1c7c6e-c340-4391-ae0e-403d6e074441)
