### PR TITLE
QOLDEV-422 Fixing qg-date-input

### DIFF
--- a/src/assets/_project/_blocks/utils/qg-datepicker.js
+++ b/src/assets/_project/_blocks/utils/qg-datepicker.js
@@ -11,7 +11,7 @@ if (!browserSupportsDateInput() && $('input[type=\'date\']').length > 0) {
   });
 }
 // 'qg-date-input' adds a jquery ui datepicker
-if ($('input[class=\'qg-date-input\']').length > 0) {
+if ($('input[class*=\'qg-date-input\']').length > 0) {
   $.getScript('{{CDN}}/latest/lib/ext/jquery-ui-bundle/jquery-ui.min.js', function () {
     $('head').append($("<link rel='stylesheet' href='{{CDN}}/latest/lib/ext/jquery-ui-bundle/jquery-ui.min.css' type='text/css' media='screen' />"));
     $('.qg-date-input').datepicker({
@@ -19,5 +19,6 @@ if ($('input[class=\'qg-date-input\']').length > 0) {
       changeYear: true,
       changeMonth: true,
     });
+    $('.qg-date-input').attr('type', 'date');
   });
 }

--- a/src/stories/components/Forms/templates/DatePicker.html
+++ b/src/stories/components/Forms/templates/DatePicker.html
@@ -4,7 +4,7 @@
     <label for="jqueryui-date">Date</label>
     <div class="form-row">
       <div class="col-12 col-sm-4">
-        <input type="text" class="qg-date-input hasDatepicker form-control" id="jqueryui-date" />
+        <input type="date" class="qg-date-input hasDatepicker form-control" id="jqueryui-date" />
       </div>
     </div>
   </div>


### PR DESCRIPTION
https://uat.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/forms#date

The date picker using qg-date-input was missing the date placeholder and also when you click on the input, the calendar wouldn't open.

The the jquery syntax was not right. $('input[class=\'qg-date-input\']').length is always 0. It was missing an asterisk. 

**Before:**

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/ae49b831-c411-4f82-af33-7e4e68aabfc2)

**After:**

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/86238a2d-9abe-4f6b-a527-280701cb41f0)
