### PR TITLE
QOLDEV-443 Replacing no-print with d-print-none

### DIFF
--- a/src/assets/_project/_blocks/layout/footer/footer-legals.html
+++ b/src/assets/_project/_blocks/layout/footer/footer-legals.html
@@ -1,13 +1,13 @@
 <div class="qg-legal d-flex flex-wrap align-items-end justify-content-between">
 	<ul class="list-inline col-lg-6 col-md-6">
-		<li><a href="https://www.qld.gov.au/help/" class="no-print">Help</a></li>
+		<li><a href="https://www.qld.gov.au/help/" class="d-print-none">Help</a></li>
 		<li><a href="https://www.qld.gov.au/legal/copyright/">Copyright</a></li>
 		<li><a href="https://www.qld.gov.au/legal/disclaimer/">Disclaimer</a></li>
 		<li><a href="https://www.qld.gov.au/legal/privacy/">Privacy</a></li>
 		<li><a href="https://www.qld.gov.au/right-to-information/">Right to information</a></li>
-		<li><a href="https://www.qld.gov.au/help/accessibility/" class="no-print">Accessibility</a></li>
-		<li><a href="http://www.smartjobs.qld.gov.au/" class="no-print">Jobs in Queensland Government</a></li>
-		<li id="link-languages"><a href="https://www.qld.gov.au/languages/" class="no-print">Other languages</a></li>
+		<li><a href="https://www.qld.gov.au/help/accessibility/" class="d-print-none">Accessibility</a></li>
+		<li><a href="http://www.smartjobs.qld.gov.au/" class="d-print-none">Jobs in Queensland Government</a></li>
+		<li id="link-languages"><a href="https://www.qld.gov.au/languages/" class="d-print-none">Other languages</a></li>
 	</ul>
   	<p class="qg-copyright col-lg-4 col-md-4">&copy; The State of Queensland <span id="qg-copyright-daterange"></span></p>
 </div>


### PR DESCRIPTION
Replacing `no-print` with bootstrap `d-print-none`. A few instances were missed.