### PR TITLE
QOLDEV-458 Removing top borderfram the card's footer

### DIFF
--- a/src/assets/_project/_blocks/components/misc/_qg-cards.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-cards.scss
@@ -24,8 +24,7 @@
   }
 
   .qg-card__footer {
-    padding: 1em;
-    border-top: 1px solid hsla(0, 0%, 50%, 0.7);
+    padding: 0 1em 1em;
     //this condition is to support legacy Aggregation page HTML
     .btn {
       width: 100%;
@@ -57,7 +56,6 @@
       }
 
       .qg-card__footer {
-        border-top: 1px solid rgba(211, 211, 211, 1);
         .btn-link {
           @include qg-link-styles__default;
         }


### PR DESCRIPTION
https://uat.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/cards#content_container_250117

The top border is removed from the card footer to save some space.

**Before:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/0179e54c-2cff-49b7-8dbe-ba36fb0f01cd)

**After:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/14bd81c5-e268-4a9d-be58-25cbf2d3eb6f)
