### PR TITLE
QOLDEV-74 Applying default zero margin for the image link inside qg-fig

### DIFF
--- a/src/assets/_project/_blocks/components/misc/_qg-images.scss
+++ b/src/assets/_project/_blocks/components/misc/_qg-images.scss
@@ -61,6 +61,7 @@
     display: block;
     text-align: right;
     position: relative;
+    margin: 0 !important;
     &:hover {
       >span, >img:not(.figure__expand-icon) {
         outline: 1px solid #0066CC;


### PR DESCRIPTION
Applying zero margin to the a[data-fancybox] within qg-fig.
https://uat.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/images#larger

https://oss-uat.clients.squiz.net/environment/management/environmental/offsets/what-when

**Before:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/0d125d87-8695-4688-9d2a-e63dd0cfc58d)
