### PR TITLE
QOLDEV-443 Defining no-print class just in case it is used in Squiz content

### DIFF
--- a/src/assets/_project/_blocks/layout/_print.scss
+++ b/src/assets/_project/_blocks/layout/_print.scss
@@ -309,3 +309,7 @@
       border: none;
   }
 }
+
+.no-print {
+  @extend .d-print-none;
+}


### PR DESCRIPTION
`no-print `class used to exist in SWE. Adding it back in order to make print work as expected just in case it is used anywhere in the Squiz content.