### PR TITLE
QOLDEV-400 reduced margins on P + UL in asides to align to global pat…

### DIFF
--- a/src/assets/_project/_blocks/layout/asides/_asides.scss
+++ b/src/assets/_project/_blocks/layout/asides/_asides.scss
@@ -1,5 +1,6 @@
 //// asides ////
 @import 'minicart';
+
 #qg-content #qg-secondary-content {
   position: relative;
 
@@ -47,6 +48,7 @@
     p:last-child {
       margin-bottom: 0;
     }
+    
     ul {
       // Check in other patterns to see this padding is of no use
       //padding-left: 1.5em;
@@ -55,10 +57,17 @@
       }
     }
 
+    //Reduce the bottom margin of paragraphs if is adjacent (followed direclty by) an UL or OL
+    p:has( + ul),
+    p:has( + ol) {
+      margin-bottom: 0.5rem;
+    }
+
     .tel {
       font-weight: 800;
       white-space: nowrap;
     }
+
     &.qg-featured {
       .news-items {
         h3 {


### PR DESCRIPTION
This change reduces the margin between P and lists (UL's and OL's) on aside content.  This changed is required to align to  the global pattern. 

The change will not be reflected in Firefox until support for :has selector becomes available in FF later this year. 

Original margin: 0.75rem
New margin: 0.5rem

Original
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438309/71ed012f-4791-4a89-bfd7-e268df2f3867)

New
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438309/de4cf936-33a7-4b3d-9c59-07f60cb3eaa6)
