### PR TITLE
QOLDEV-501 Resolving callout chromatic test regarding icon

### DIFF
--- a/e2e/__tests__/components/call-out-box-test.js
+++ b/e2e/__tests__/components/call-out-box-test.js
@@ -15,7 +15,7 @@ describe('SWE Components testing', () => {
     page.on('console', consoleObj => { consoleMsg = consoleObj.text(); });
     await page.goto(`${ct.APP_URL}/docs/components/call-out-box.html`, { waitUntil: 'networkidle0' });
     // 1. -> call out box contains deprecate icon
-    await page.waitForSelector('.qg-callout__box .qg-callout__icon span.fa');
+    await page.waitForSelector('.qg-callout__box .qg-callout__icon i.fa');
     // 2. -> warning appears in console
     await page.waitForTimeout(5000);
     expect(consoleMsg).toEqual('Please change the font awesome element in Callout box from i to span, we\'ll be removing the css in this element before 22nd june 2022. Please refer to the https://github.com/qld-gov-au/qg-web-template/pull/391 for more details.');

--- a/src/docs/components/call-out-box.html
+++ b/src/docs/components/call-out-box.html
@@ -173,7 +173,7 @@
         <section class="qg-callout__box qg-callout__grey-theme">
           <div class="qg-callout__header col-12">
             <span class="qg-callout__icon">
-              <span class="fa fa-comments"></span>
+              <i class="fa fa-comments"></i>
             </span>
             <h2 class="qg-callout__title">Call out box using &lt;i&gt; as Font Awesome icon</h2>
           </div>

--- a/src/docs/components/call-out-box.html
+++ b/src/docs/components/call-out-box.html
@@ -88,9 +88,9 @@
           <div class="panel-body">
             <section class="qg-callout__box qg-callout__grey-theme">
               <div class="qg-callout__header col-12">
-                                            <span class="qg-callout__icon">
-                            <span class="fa fa-comments"></span>
-                         </span>
+                <span class="qg-callout__icon">
+                  <span class="fa fa-comments"></span>
+                </span>
                 <h2 class="qg-callout__title">Tell us what you think about our website</h2>
               </div>
 
@@ -173,7 +173,7 @@
         <section class="qg-callout__box qg-callout__grey-theme">
           <div class="qg-callout__header col-12">
             <span class="qg-callout__icon">
-              <i class="fa fa-comments"></i>
+              <span class="fa fa-comments"></span>
             </span>
             <h2 class="qg-callout__title">Call out box using &lt;i&gt; as Font Awesome icon</h2>
           </div>
@@ -188,7 +188,7 @@
         <p>Please modify your code from:</p>
         <pre>
         <code class="language-markup">&lt;span class=&quot;qg-callout__icon&quot;&gt;
-          &lt;i class=&quot;fa fa-comments&quot;&gt;&lt;/i&gt;
+          &lt;span class=&quot;fa fa-comments&quot;&gt;&lt;/span&gt;
         &lt;/span&gt;</code></pre>
         <p>to:</p>
         <pre>


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/_resources/matrix-documentation/components/callout/_admin/?screen=contents&assetid=140042

[Callout](https://www.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/callout) 

Based on callout-box-test.js in SWE < i > before font awesome icon needs to be replaced by <span>.

This causes test to fail.

This needs to be be fixed both in Callout in Squiz #140042 and SWE documentations.