### PR TITLE
QOLDEV 386 fix filesummary js function

### DIFF
--- a/src/assets/_project/_blocks/components/misc/qg-document-links.js
+++ b/src/assets/_project/_blocks/components/misc/qg-document-links.js
@@ -1,29 +1,32 @@
-(function ($) {
-  'use strict';
-  let linkType = '.PDF$|.DOC$|.DOCX$|.XLS$|.XLSX$|.RTF$';
-  let contentType = 'PDF|DOC|DOCX|XLS|XLSX|RTF';
-  $(document).ready(function () {
-    $('a', '#qg-primary-content, #qg-secondary-content').each(function () {
-      let $this = $(this);
-      let linkRegex = new RegExp(linkType, 'i');
-      // check to see if a link with a selected linkType exist
-      // Example - cue-template-change-log.pdf|rtf...
-      if (linkRegex.test($this.attr('href'))) {
-        let contentRegex = new RegExp(contentType);
-        let currContent = $this.text();
-        if (/\.\d*?/.test(currContent)) {
-          // check to see if decimals exist, if yes then round then off
-          // Example (PDF 106.66) -> (PDF 106)
-          let extractSize = new RegExp('\\((?:' + contentType.toUpperCase() + '),?\\s+[0-9\\.]+\\s*[KM]B\\)', 'i');
-          currContent.match(extractSize) ? $(this).find('.meta').empty().append(currContent.match(extractSize)[0].toUpperCase().replace(/(\.\d*)/gi, '')) : '';
-        } else if (!contentRegex.test(currContent)) {
-          // check to see there is no doc type present in the content section
-          // If yes then insert <span class="meta">PDF</span>
-          let linkText = $this.attr('href').replace(/^.*\.(.+)$/, '$1').toUpperCase();
-          $this.append(' <span class="meta">(' + linkText + ')</span>');
-        }
-      }
-    });
-  });
-}(jQuery));
+// This function looks for file summary strings on a page and reformats values for consistency and readability.
+// It is an update a previous SWE function with the same behaviour.
+// It has been converted from jQuery to vanilla JS and it now rounds up filesize values. The previous function stripped all values after the decimal point.
 
+// 1. looks for this file summary pattern: for example "(PDF, 1.3 MB) or (DOCX 23.5KB)" on all links (A tags) in the DOM
+// 2. checks the HREF of the link ends in .PDF, .RTF etc
+// 3. reformats the file summary for consistency (PDF 517 KB)
+// 4. Rounds UP the file size value to the nearest whole integer
+// 5. Assumes a bias for over inflated sizes. e.g. 1.3 MB will round up to 2 MB
+// SP
+
+document.addEventListener('DOMContentLoaded', () => {
+  const filePattern = /\.(?:PDF|DOC|DOCX|XLS|XLSX|RTF)$/i;
+  const summaryPattern = /\((PDF|DOC|DOCX|XLS|XLSX|RTF)\s*,?\s*([\d.]+)\s*(KB|MB|GB)\)/i;
+
+  const elements = document.querySelectorAll('#qg-primary-content a, #qg-secondary-content a');
+
+  elements.forEach((element) => {
+    const fileMatch = element.href.match(filePattern);
+    const summaryMatch = element.text.match(summaryPattern);
+
+    if (fileMatch && summaryMatch) {
+      const originalSummary = summaryMatch[0]; // "(PDF 1.56MB)"
+      const contentType = summaryMatch[1].toUpperCase(); // "PDF"
+      const fileSize = Math.ceil(parseFloat(summaryMatch[2])); // 1.56
+      const fileSizeUnit = summaryMatch[3].toUpperCase(); // "MB"
+
+      const newSummary = `<span class="meta">(${contentType}, ${fileSize} ${fileSizeUnit})</span>`;
+      element.innerHTML = element.textContent.replace(originalSummary, newSummary); //(PDF 1.6 MB)
+    }
+  });
+});

--- a/src/assets/_project/_blocks/components/misc/qg-document-links.js
+++ b/src/assets/_project/_blocks/components/misc/qg-document-links.js
@@ -7,7 +7,6 @@
 // 3. reformats the file summary for consistency (PDF 517 KB)
 // 4. Rounds UP the file size value to the nearest whole integer
 // 5. Assumes a bias for over inflated sizes. e.g. 1.3 MB will round up to 2 MB
-// SP
 
 document.addEventListener('DOMContentLoaded', () => {
   const filePattern = /\.(?:PDF|DOC|DOCX|XLS|XLSX|RTF)$/i;


### PR DESCRIPTION
This function looks for file summary strings on a page and reformats values for consistency and readability.

It is an update a previous SWE function with the same behaviour, but been converted from jQuery to vanilla JS and now rounds up file size values. The previous function stripped all values after the decimal point.

1. looks for this file summary pattern: for example "(PDF, 1.3 MB) or (DOCX 23.5KB)" on all links (A tags) in the DOM
2. checks the HREF of the link ends in .PDF, .RTF etc
3. reformats the file summary for consistency (PDF 517 KB)
4. Rounds UP the file size value to the nearest whole integer
5. Assumes a bias for over inflated sizes. e.g. 1.3 MB will round up to 2 MB

Original behaviour
(PDF 1.9 MB) was reformatted to (PDF 1 MB)

New behaviour
(PDF 1.9 MB) is reformatted to (PDF 2 MB)
