### PR TITLE
Qoldev 515 funnelack upgrade set location

### DIFF
--- a/e2e/__tests__/components/funnelback-search-test.js
+++ b/e2e/__tests__/components/funnelback-search-test.js
@@ -21,7 +21,7 @@ describe('SWE Header testing', () => {
     await page.waitForTimeout(ct.WT);
     expect(
       await page.$$eval('.qg-search-concierge-content li button', nodes => nodes.map(n => n.textContent)),
-    ).toEqual(['jobs in qld government', 'jobs', 'jobs in the queensland government']);
+    ).toEqual(['jobs in qld government', 'jobs', 'government jobs']);
   });
 
   afterAll(async () => {

--- a/e2e/__tests__/components/funnelback-search-test.js
+++ b/e2e/__tests__/components/funnelback-search-test.js
@@ -21,7 +21,7 @@ describe('SWE Header testing', () => {
     await page.waitForTimeout(ct.WT);
     expect(
       await page.$$eval('.qg-search-concierge-content li button', nodes => nodes.map(n => n.textContent)),
-    ).toEqual(['jobs in qld government', 'jobs', 'government jobs']);
+    ).toEqual(['jobs in queensland government', 'jobs', 'government jobs']);
   });
 
   afterAll(async () => {

--- a/e2e/__tests__/layout/footer-feedback-test.js
+++ b/e2e/__tests__/layout/footer-feedback-test.js
@@ -12,14 +12,18 @@ beforeAll(async () => {
 
 describe('SWE Footer testing', () => {
   test('Footer feedback', async () => {
+
     await page.click('.qg-feedback-toggle');
+
     // check getRecaptcha input value is populated as expected and is false by default
     await page.waitForTimeout(ct.WT);
     const getRecaptcha =  await page.$eval('input[name=g-recaptcha-response]', el => $(el).val());
     expect(getRecaptcha).toMatch(/false/);
-    await page.click('#page-feedback-about-this-website');
-    await page.click('#fs-very-satisfied');
+
+    await page.click('label[for="page-feedback-about-this-website"]');
+    await page.click('label[for="fs-very-satisfied"]');
     await page.type('#comments', 'Useful website', { delay: 20 });
+
     // this test case causing massive fail in circleci, which have issue when submitting a real form with remote api, disabled this test for now.
     // as we are moving out from circleci, Github Actions pipeline doesn't has this issues
     /*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Queensland-Government-Web-Template",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "description": "This template is designed to provide a template for all Franchise websites, and the underpinning technology for new Agency websites.",
   "main": "gulpfile.babel.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "jest-puppeteer": "^7.0.0",
     "node-ssi": "^0.3.2",
     "np": "^7.6.3",
-    "puppeteer": "^19.6.3",
+    "puppeteer": "^20.9.0",
     "sass": "^1.61.0",
     "storybook-addon-pseudo-states": "^1.15.2",
     "string-replace-loader": "^3.1.0",

--- a/src/assets/_project/_blocks/components/site-search/qg-site-search.js
+++ b/src/assets/_project/_blocks/components/site-search/qg-site-search.js
@@ -382,7 +382,11 @@ $(function () {
     // Look for services in standard results
     if (allResults.length > 0) {
       var filteredResults = allResults.filter(function (result) {
-        return result['metaData']['sfinder'] === 'yes';
+        if (result['listMetadata'] != null && result['listMetadata']['sfinder'] != null) {
+          return result['listMetadata']['sfinder'] === 'yes';
+        } else {
+          return false;
+        }
       });
 
       serviceResults = serviceResults.concat(filteredResults);

--- a/src/assets/_project/_blocks/layout/footer/_service-centre.scss
+++ b/src/assets/_project/_blocks/layout/footer/_service-centre.scss
@@ -64,12 +64,12 @@
                 position: absolute;
             }
 
-            &:nth-child(1):before {
-                content: "\f05a";
+            &.service-info:before {
+                content: "\f05a"; // inforamation icon
             }
 
-            &:nth-child(2):before {
-                content: "\f14e";
+            &.centre-distance:before {
+                content: "\f14e"; // compass icon
             }
         }
     }

--- a/src/assets/_project/_blocks/layout/location/qg-location.js
+++ b/src/assets/_project/_blocks/layout/location/qg-location.js
@@ -767,15 +767,18 @@ $(function () {
       centreData = results[0];
     }
 
-    if (centreData) {
-      var centreName = centreData['metaData']['t'];
-      var centreID = centreData['metaData']['id'];
+    if (centreData && centreData['listMetadata']) {
+      var centreName = centreData['listMetadata']['t'];
+      var centreID = centreData['listMetadata']['id'];
       var centreDistance = centreData['kmFromOrigin'];
-      var centreAddress1 = centreData['metaData']['address1'];
-      var centreAddress2 = centreData['metaData']['address2'];
+      var centreAddress1 = centreData['listMetadata']['address1'];
+      var centreAddress2 = centreData['listMetadata']['address2'];
 
       // Build URL
-      var centreType = centreData['metaData']['datasource'].toLowerCase();
+      var centreType = centreData['listMetadata']['datasource'];
+      if (centreType !== undefined) {
+        centreType = centreType[0].toLowerCase();
+      }
       var centreURL = centreContainer.attr('data-' + centreType);
 
       // Handle special cases
@@ -790,10 +793,12 @@ $(function () {
       // Build HTML
       centreHTML += '<a href="' + centreURL + '" class="qg-service-centre__link" data-analytics-link-group="qg-nearest-service-centre-details">' + centreName + '</a>';
       centreHTML += '<ul class="qg-service-centre-list">';
-      centreHTML += '<li class="qg-service-centre-list-item">';
+      centreHTML += '<li class="qg-service-centre-list-item service-info">';
       centreHTML += '<a href="' + centreURL + '" data-analytics-link-group="qg-nearest-service-centre-services">Services available</a>';
       centreHTML += '</li>';
-      centreHTML += '<li class="qg-service-centre-list-item">' + centreDistance + ' km away</li>';
+      if (centreDistance !== null) {
+        centreHTML += '<li class="qg-service-centre-list-item centre-distance">' + centreDistance + ' km away</li>';
+      }
       centreHTML += '<li class="qg-service-centre-list-item">';
       if (centreAddress1 !== undefined) {
         centreHTML += '<span class="qg-service-centre__address">' + centreAddress1 + '</span>';
@@ -868,3 +873,4 @@ $(function () {
   $('body').on('click', '.qg-location-setter-close', qgLocation.fn.closeServiceCentre);
   $('body').on('keydown', '.qg-location-setter-autocomplete button', qgLocation.fn.keyboardNavigation);
 });
+

--- a/src/assets/_project/_blocks/layout/service-centre/service-centre.html
+++ b/src/assets/_project/_blocks/layout/service-centre/service-centre.html
@@ -1,4 +1,4 @@
-<div class="qg-service-centre__wrapper" data-types="QGAP; HSC" data-centres="https://find.search.qld.gov.au/s/search.json?collection=services-web&sort=prox&num_ranks=2">
+<div class="qg-service-centre__wrapper" data-types="QGAP; HSC" data-centres="https://discover.search.qld.gov.au/s/search.json?collection=qgov~sp-services&sort=prox&num_ranks=2">
     <div class="qg-location-default">
         <p>Help us provide you with the most useful information by setting your location.</p>
         <button class="btn btn-global-primary-white qg-service-centre-set-location collapsed" data-analytics-link-group="“qg-nearest-service-set-location“" data-toggle="collapse" data-target="#qg-service-centre-location-setter" role="button" aria-expanded="false" aria-controls="qg-service-centre-location-setter">

--- a/src/assets/_project/_blocks/layout/site-search-form.html
+++ b/src/assets/_project/_blocks/layout/site-search-form.html
@@ -1,4 +1,4 @@
-<form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&profile=qld&meta_sfinder_sand=yes">
+<form action="https://www.qld.gov.au/search" id="qg-global-search-form" role="search" class="qg-site-search__form qg-search-form collapse qg-global-web-autocomplete" data-suggestions="https://discover.search.qld.gov.au/s/suggest.json?collection=qgov~sp-search&fmt=json%2B%2B&alpha=0.5&profile=qld" data-results-url="https://discover.search.qld.gov.au/s/search.json?collection=qgov~sp-search&profile=qld&meta_sfinder_sand=yes">
     <div class="input-group">
       <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
       <input type="text" name="query" id="qg-search-query" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox"/>
@@ -84,6 +84,6 @@
     <!--parameters to display results on search page-->
     <input type="hidden" name="num_ranks" value="10">
     <input type="hidden" name="tiers" value="off">
-    <input type="hidden" name="collection" value="qld-gov">
+    <input type="hidden" name="collection" value="qgov~sp-search">
     <input type="hidden" name="profile" value="qld">
 </form>

--- a/src/stories/components/Header/templates/Search.html
+++ b/src/stories/components/Header/templates/Search.html
@@ -1,4 +1,4 @@
-<form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete qg-site-search__form" data-suggestions="https://find.search.qld.gov.au/s/suggest.json?collection=qld-gov&amp;fmt=json%2B%2B&amp;alpha=0.5&amp;profile=qld" data-results-url="https://find.search.qld.gov.au/s/search.json?collection=qld-gov&amp;profile=qld&amp;smeta_sfinder_sand=yes" novalidate="true">
+<form action="https://oss-uat.clients.squiz.net/search" id="qg-global-search-form" role="search" class="qg-search-form collapse qg-global-web-autocomplete qg-site-search__form" data-suggestions="https://discover.search.qld.gov.au/s/suggest.json?collection=qgov~sp-search&amp;fmt=json%2B%2B&amp;alpha=0.5&amp;profile=qld" data-results-url="https://discover.search.qld.gov.au/s/search.json?collection=qgov~sp-search&amp;profile=qld&amp;smeta_sfinder_sand=yes" novalidate="true">
     <div class="input-group">
       <label for="qg-search-query" class="qg-visually-hidden">Search Queensland Government</label>
       <input type="text" name="query" id="qg-search-query" accesskey="5" class="form-control qg-search-site__input" autocomplete="off" placeholder="Search website" tabindex="0" aria-expanded="false" role="combobox">
@@ -63,6 +63,6 @@
     <!--parameters to display results on search page-->
     <input type="hidden" name="num_ranks" value="10">
     <input type="hidden" name="tiers" value="off">
-    <input type="hidden" name="collection" value="qld-gov">
+    <input type="hidden" name="collection" value="qgov~sp-search">
     <input type="hidden" name="profile" value="qld">
 </form>


### PR DESCRIPTION
Version 4.2.3 will be released before 4.3.0 for Funnelback upgrade.
- Set your location in the footer https://oss-uat.clients.squiz.net/services

 ![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/4403c9cf-0f6f-4248-aa06-ae8d83b3953a)

 ![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/5568571b-48c1-463d-9a70-86f99c29e72d)

 Squiz will be working on missing kmFromOrigin. When fixed it will appear in the footer as well.
- Also updating Search story file with the new search domain and collection string.
- footer-feedback-test.js needed to get updated to resolve test failure. This was done in 4.3.0.
- puppeteer version had to increase to resolve another build error. This was done in 4.3.0 as well.