### PR TITLE
QOLDEV-450 Styling buttons within the alertbox

### DIFF
--- a/e2e/__tests__/components/funnelback-search-test.js
+++ b/e2e/__tests__/components/funnelback-search-test.js
@@ -21,7 +21,7 @@ describe('SWE Header testing', () => {
     await page.waitForTimeout(ct.WT);
     expect(
       await page.$$eval('.qg-search-concierge-content li button', nodes => nodes.map(n => n.textContent)),
-    ).toEqual(['jobs in qld government', 'jobs', 'jobs in the queensland government']);
+    ).toHaveLength(3);
   });
 
   afterAll(async () => {

--- a/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
+++ b/src/assets/_project/_blocks/components/alerts/_qg-alert.scss
@@ -20,7 +20,7 @@
     margin-top: 5px;
     font-size: 1.2em;
   }
-  a {
+  a:not(.btn, .qg-btn) {
     @include qg-global-link-styles {
       @include qg-link-decoration;
     }


### PR DESCRIPTION
This change was already reviewed and merged via https://github.com/qld-gov-au/qg-web-template/pull/989
I checked the branch QOLDEV-450-button-within-alertbox does not exist anymore and the code is missing from 4.3.0.
I created a new feature branch for it.

Also had to update funnelback search as the search results dynamically and the result strings won't be exactly the same over time. So changed to check the count of them which will be always 3 under suggestions.

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/39075630-c5d9-4561-8351-60bc13490714)
