### PR TITLE
QOLDEV-553 Styling social media links

### DIFF
--- a/src/assets/_project/_blocks/layout/content/_options.scss
+++ b/src/assets/_project/_blocks/layout/content/_options.scss
@@ -7,6 +7,10 @@
 .qg-share {
   margin: 10px 0 30px;
 
+  .qg-share-link {
+    padding-top: 3px;
+  }
+
   &__title {
     @include rem(font-size, 14px);
     color: $qg-global-primary-darker-grey;


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/housing/buying-owning-home/financial-help-concessions/resilient-homes-fund
Aligning social media icon outlines to fix in FireFox and Safari.

**Before:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/daba2c6c-2f20-422e-bcc7-a8ec57a10a5d)
