### PR TITLE
Resolving quick exit test failure after puppeteer upgrade

### DIFF
--- a/e2e/__tests__/components/quick-exit-test.js
+++ b/e2e/__tests__/components/quick-exit-test.js
@@ -28,7 +28,6 @@ describe('SWE Components testing', () => {
     await page.waitForTimeout(ct.WT);
     expect(await page.evaluate(() => location.href)).toBe('https://www.google.com.au/');
     await page.goBack();
-    //await page.waitForTimeout(ct.WT);
     expect(await page.evaluate(() => location.href)).not.toBe(`${ct.APP_URL}/docs/quick-exit.html`);
   }, ct.TO);
 

--- a/e2e/__tests__/components/quick-exit-test.js
+++ b/e2e/__tests__/components/quick-exit-test.js
@@ -21,7 +21,7 @@ describe('SWE Components testing', () => {
     // 3. -> 'tips to browse safely' navigating to the correct link
     await page.click('.qg-quick-exit__tip-link');
     await page.waitForTimeout(ct.WT);
-    expect(await page.evaluate(() => location.href)).toBe('https://www.qld.gov.au/help/tips-to-browse-safely-online');
+    expect(await page.evaluate(() => location.href)).toBe(`${ct.APP_URL}/help/tips-to-browse-safely-online`);
     await page.goBack();
     // 4. -> 'close this site' is working as expected and browser back is not taking to the same page
     await page.click('.qg-quick-exit__button');

--- a/e2e/__tests__/components/quick-exit-test.js
+++ b/e2e/__tests__/components/quick-exit-test.js
@@ -28,7 +28,7 @@ describe('SWE Components testing', () => {
     await page.waitForTimeout(ct.WT);
     expect(await page.evaluate(() => location.href)).toBe('https://www.google.com.au/');
     await page.goBack();
-    await page.waitForTimeout(ct.WT);
+    //await page.waitForTimeout(ct.WT);
     expect(await page.evaluate(() => location.href)).not.toBe(`${ct.APP_URL}/docs/quick-exit.html`);
   }, ct.TO);
 

--- a/e2e/__tests__/components/quick-exit-test.js
+++ b/e2e/__tests__/components/quick-exit-test.js
@@ -21,15 +21,15 @@ describe('SWE Components testing', () => {
     // 3. -> 'tips to browse safely' navigating to the correct link
     await page.click('.qg-quick-exit__tip-link');
     await page.waitForTimeout(ct.WT);
-    expect(await page.evaluate(() => location.href)).toBe(`${ct.APP_URL}/help/tips-to-browse-safely-online`);
+    expect(await page.evaluate(() => location.href)).toBe('https://www.qld.gov.au/help/tips-to-browse-safely-online');
     await page.goBack();
     // 4. -> 'close this site' is working as expected and browser back is not taking to the same page
     await page.click('.qg-quick-exit__button');
     await page.waitForTimeout(ct.WT);
     expect(await page.evaluate(() => location.href)).toBe('https://www.google.com.au/');
-    await page.goBack();
-    await page.waitForTimeout(ct.WT);
-    expect(await page.evaluate(() => location.href)).not.toBe(`${ct.APP_URL}/docs/quick-exit.html`);
+    //await page.goBack();
+    //await page.waitForTimeout(ct.WT);
+    //expect(await page.evaluate(() => location.href)).not.toBe(`${ct.APP_URL}/docs/quick-exit.html`);
   }, ct.TO);
 
   afterAll(async () => {

--- a/e2e/__tests__/components/quick-exit-test.js
+++ b/e2e/__tests__/components/quick-exit-test.js
@@ -27,9 +27,9 @@ describe('SWE Components testing', () => {
     await page.click('.qg-quick-exit__button');
     await page.waitForTimeout(ct.WT);
     expect(await page.evaluate(() => location.href)).toBe('https://www.google.com.au/');
-    //await page.goBack();
-    //await page.waitForTimeout(ct.WT);
-    //expect(await page.evaluate(() => location.href)).not.toBe(`${ct.APP_URL}/docs/quick-exit.html`);
+    await page.goBack();
+    await page.waitForTimeout(ct.WT);
+    expect(await page.evaluate(() => location.href)).not.toBe(`${ct.APP_URL}/docs/quick-exit.html`);
   }, ct.TO);
 
   afterAll(async () => {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "jest-puppeteer": "^7.0.0",
     "node-ssi": "^0.3.2",
     "np": "^7.6.3",
-    "puppeteer": "^20.9.0",
+    "puppeteer": "^19.6.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sass": "^1.64.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "jest-puppeteer": "^7.0.0",
     "node-ssi": "^0.3.2",
     "np": "^7.6.3",
-    "puppeteer": "^19.6.3",
+    "puppeteer": "^20.9.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "sass": "^1.64.0",


### PR DESCRIPTION
New version of puppeteer which is 20.9.0 caused quick exit test to fail. Removing waitForTimeout fixed it.
Error: Execution context was destroyed, most likely because of a navigation.