### PR TITLE
QOLDEV-574 Resolving deprecated storybook codes

### DIFF
--- a/src/assets/_project/lib/ext/butterfly/jquery.butterfly.js
+++ b/src/assets/_project/lib/ext/butterfly/jquery.butterfly.js
@@ -81,13 +81,13 @@ jQuery.butterfly.linkCount = 0;
 /**
  * Standard key mappings
  */
-	DOM_VK_END    = 35;
-	DOM_VK_HOME   = 36;
-	DOM_VK_LEFT   = 37;
-	DOM_VK_UP     = 38;
-	DOM_VK_RIGHT  = 39;
-	DOM_VK_DOWN   = 40;
-	DOM_VK_ESCAPE = 27;
+const DOM_VK_END    = 35;
+const DOM_VK_HOME   = 36;
+const DOM_VK_LEFT   = 37;
+const DOM_VK_UP     = 38;
+const DOM_VK_RIGHT  = 39;
+const DOM_VK_DOWN   = 40;
+const DOM_VK_ESCAPE = 27;
 
 (function( $, ResizeEvents ) {// start closure
 	'use strict';

--- a/src/stories/Deploy.mdx
+++ b/src/stories/Deploy.mdx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
-import { Markdown } from '@storybook/addon-docs/blocks';
+import { Markdown } from '@storybook/blocks';
 
 import Readme from "../../readme/deploy.md?raw"
 

--- a/src/stories/GettingStarted.mdx
+++ b/src/stories/GettingStarted.mdx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
-import { Markdown } from '@storybook/addon-docs/blocks';
+import { Markdown } from '@storybook/blocks';
 
 import Readme from "../../readme/getting-started.md?raw"
 

--- a/src/stories/Git.mdx
+++ b/src/stories/Git.mdx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
-import { Markdown } from '@storybook/addon-docs/blocks';
+import { Markdown } from '@storybook/blocks';
 
 import Readme from "../../readme/git.md?raw"
 

--- a/src/stories/Introduction.mdx
+++ b/src/stories/Introduction.mdx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
-import { Markdown } from '@storybook/addon-docs/blocks';
+import { Markdown } from '@storybook/blocks';
 
 import Readme from "../../readme/develop-in-storybook.md?raw"
 

--- a/src/stories/MakingChanges.mdx
+++ b/src/stories/MakingChanges.mdx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
-import { Markdown } from '@storybook/addon-docs/blocks';
+import { Markdown } from '@storybook/blocks';
 
 import Readme from "../../readme/making-changes.md?raw"
 

--- a/src/stories/TechInUse.mdx
+++ b/src/stories/TechInUse.mdx
@@ -1,5 +1,5 @@
 import { Meta } from '@storybook/addon-docs';
-import { Markdown } from '@storybook/addon-docs/blocks';
+import { Markdown } from '@storybook/blocks';
 
 import Readme from "../../readme/tech-in-use.md?raw"
 

--- a/src/stories/components/Accordion/Accordion.stories.mdx
+++ b/src/stories/components/Accordion/Accordion.stories.mdx
@@ -21,31 +21,31 @@ import States from "./templates/States.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>{() => Default}</Story>
 </Canvas>
 
 ## Subtitle
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Subtitle" parameters={getDecoratedParameters(Subtitle)}>{() => Subtitle}</Story>
 </Canvas>
 
 ## Icon
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Icon" parameters={getDecoratedParameters(Icon)}>{() => Icon}</Story>
 </Canvas>
 
 ## Expandable
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Expandable" parameters={getDecoratedParameters(Expandable)}>{() => Expandable}</Story>
 </Canvas>
 
 ## States
 
-<Canvas withSource="close">
+<Canvas sourceState="hidden">
   <Story
     name="States"
     decorators={[Grid(2)]} parameters={getDecoratedParameters(States)}
@@ -56,7 +56,7 @@ import States from "./templates/States.html";
 
 ## Mobile
 
-<Canvas withSource="none" {...getCanvasMobileProps()}>
+<Canvas sourceState="none" {...getCanvasMobileProps()}>
   <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>
     {() => Mobile}
   </Story>

--- a/src/stories/components/Alert/Alert.stories.mdx
+++ b/src/stories/components/Alert/Alert.stories.mdx
@@ -14,24 +14,24 @@ import Critical from "./templates/Critical.html";
 
 ## Information
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Information" parameters={getDecoratedParameters(Information)}>{() => Information}</Story>
 </Canvas>
 
 ## Success
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Success" parameters={getDecoratedParameters(Success)}>{() => Success}</Story>
 </Canvas>
 
 ## Warning
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Warning" parameters={getDecoratedParameters(Warning)}>{() => Warning}</Story>
 </Canvas>
 
 ## Critical
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Critical" parameters={getDecoratedParameters(Critical)}>{() => Critical}</Story>
 </Canvas>

--- a/src/stories/components/Aside/Aside.stories.mdx
+++ b/src/stories/components/Aside/Aside.stories.mdx
@@ -13,7 +13,7 @@ Requires `#QgContent` ancestor.
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Default"
     parameters={{
@@ -30,7 +30,7 @@ Requires `#QgContent` ancestor.
 
 ## Icon
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Icon"
     parameters={{

--- a/src/stories/components/Banner/Banner.stories.mdx
+++ b/src/stories/components/Banner/Banner.stories.mdx
@@ -11,7 +11,7 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/Blockquote/Blockquote.stories.mdx
+++ b/src/stories/components/Blockquote/Blockquote.stories.mdx
@@ -13,7 +13,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/src/stories/components/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -13,7 +13,7 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default">
     {() => Default}
   </Story>

--- a/src/stories/components/Buttons/Buttons.stories.mdx
+++ b/src/stories/components/Buttons/Buttons.stories.mdx
@@ -17,7 +17,7 @@ import Links from "./templates/Links.html";
 
 ## Primary
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Primary" parameters={getDecoratedParameters(Primary)}>
     {() => Primary}
   </Story>
@@ -25,7 +25,7 @@ import Links from "./templates/Links.html";
 
 ## Secondary
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Secondary" parameters={getDecoratedParameters(Secondary)}>
     {() => Secondary}
   </Story>
@@ -33,7 +33,7 @@ import Links from "./templates/Links.html";
 
 ## Tertiary
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Tertiary" parameters={getDecoratedParameters(Tertiary)}>
     {() => Tertiary}
   </Story>
@@ -41,7 +41,7 @@ import Links from "./templates/Links.html";
 
 ## Outline
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Outline" parameters={getDecoratedParameters(Outline)}>
     {() => Outline}
   </Story>
@@ -49,7 +49,7 @@ import Links from "./templates/Links.html";
 
 ## Loading
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Loading" parameters={getDecoratedParameters(Loading)}>
     {() => Loading}
   </Story>
@@ -57,7 +57,7 @@ import Links from "./templates/Links.html";
 
 ## States
 
-<Canvas withSource="close">
+<Canvas sourceState="hidden">
   <Story name="States" decorators={[Grid(5)]} parameters={getDecoratedParameters(States)}>
     {() => States}
   </Story>
@@ -65,7 +65,7 @@ import Links from "./templates/Links.html";
 
 ## Links
 
-<Canvas withSource="close">
+<Canvas sourceState="hidden">
   <Story name="Links" decorators={[Grid(5)]} parameters={getDecoratedParameters(Links)}>
     {() => Links}
   </Story>

--- a/src/stories/components/Callout/Callout.stories.mdx
+++ b/src/stories/components/Callout/Callout.stories.mdx
@@ -16,37 +16,37 @@ import WithImage from "./templates/WithImage.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>{() => Default}</Story>
 </Canvas>
 
 ## Blue
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Blue" parameters={getDecoratedParameters(Blue)}>{() => Blue}</Story>
 </Canvas>
 
 ## WithButtonBottom
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithButtonBottom" parameters={getDecoratedParameters(WithButtonBottom)}>{() => WithButtonBottom}</Story>
 </Canvas>
 
 ## WithButtonRight
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithButtonRight" parameters={getDecoratedParameters(WithButtonRight)}>{() => WithButtonRight}</Story>
 </Canvas>
 
 ## WithButtonLeft
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithButtonLeft" parameters={getDecoratedParameters(WithButtonLeft)}>{() => WithButtonLeft}</Story>
 </Canvas>
 
 
 ## WithImage
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithImage" parameters={getDecoratedParameters(WithImage)}>{() => WithImage}</Story>
 </Canvas>

--- a/src/stories/components/Cards/Cards.stories.mdx
+++ b/src/stories/components/Cards/Cards.stories.mdx
@@ -18,7 +18,7 @@ Requires `#QgContent` ancestor.
 
 ## Basic
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Basic" parameters={getDecoratedParameters(Basic)}>
     {() => Basic}
   </Story>
@@ -26,7 +26,7 @@ Requires `#QgContent` ancestor.
 
 ## WithActionButton
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithActionButton" parameters={getDecoratedParameters(WithActionButton)}>
     {() => WithActionButton}
   </Story>
@@ -34,7 +34,7 @@ Requires `#QgContent` ancestor.
 
 ## WithImage
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithImage" parameters={getDecoratedParameters(WithImage)}>
     {() => WithImage}
   </Story>
@@ -42,7 +42,7 @@ Requires `#QgContent` ancestor.
 
 ## WithThumbnail
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithThumbnail" parameters={getDecoratedParameters(WithThumbnail)}>
     {() => WithThumbnail}
   </Story>
@@ -50,7 +50,7 @@ Requires `#QgContent` ancestor.
 
 ## Clickable
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Clickable" parameters={getDecoratedParameters(Clickable)}>
     {() => Clickable}
   </Story>
@@ -64,7 +64,7 @@ Some style is sitting in Squiz Matrix https://www.qld.gov.au/__data/assets/css_f
 
 Not included in Forgov SWE documentation.
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="CardColumns" parameters={getDecoratedParameters(CardColumns)}>
     {() => CardColumns}
   </Story>

--- a/src/stories/components/Carousel/Carousel.stories.mdx
+++ b/src/stories/components/Carousel/Carousel.stories.mdx
@@ -11,7 +11,7 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/CopyrightLicence/CopyrightLicence.stories.mdx
+++ b/src/stories/components/CopyrightLicence/CopyrightLicence.stories.mdx
@@ -11,7 +11,7 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/CorrectIncorrect/CorrectIncorrect.stories.mdx
+++ b/src/stories/components/CorrectIncorrect/CorrectIncorrect.stories.mdx
@@ -13,7 +13,7 @@ import InTable from "./templates/InTable.html";
 
 ## Short
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Short" parameters={getDecoratedParameters(Short)}>
     {() => Short}
   </Story>
@@ -21,7 +21,7 @@ import InTable from "./templates/InTable.html";
 
 ## Long
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Long" parameters={getDecoratedParameters(Long)}>
     {() => Long}
   </Story>
@@ -29,7 +29,7 @@ import InTable from "./templates/InTable.html";
 
 ## InTable
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="InTable" parameters={getDecoratedParameters(InTable)}>
     {() => InTable}
   </Story>

--- a/src/stories/components/DocumentDownload/DocumentDownload.stories.mdx
+++ b/src/stories/components/DocumentDownload/DocumentDownload.stories.mdx
@@ -13,7 +13,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/FeatureBox/FeatureBox.stories.mdx
+++ b/src/stories/components/FeatureBox/FeatureBox.stories.mdx
@@ -18,7 +18,7 @@ Not included in Forgov SWE documentation.
 
 ## Basic
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Basic" parameters={getDecoratedParameters(Basic)}>
     {() => Basic}
   </Story>

--- a/src/stories/components/Footer/Footer.stories.mdx
+++ b/src/stories/components/Footer/Footer.stories.mdx
@@ -17,7 +17,7 @@ import Mobile from "./templates/Footer.html";
 
 {/* Footer always contributed difference in Chromatic snapshot, hence disabled snapshot temporary, need further investigation (caused by the feedback button) */}
 
-<Canvas withSource="close">
+<Canvas sourceState="hidden">
   <Story name="Default" parameters={{ chromatic: { delay: 3000, disableSnapshot: true } }}>
     {() => Default}
   </Story>
@@ -27,7 +27,7 @@ import Mobile from "./templates/Footer.html";
 
 {/* Footer always contributed difference in Chromatic snapshot, hence disabled snapshot temporary, need further investigation (caused by the feedback button) */}
 
-<Canvas withSource="none" {...getCanvasMobileProps()}>
+<Canvas sourceState="none" {...getCanvasMobileProps()}>
   <Story
     name="Mobile"
     parameters={{ ...getStoryMobileParameters(), chromatic: { disableSnapshot: true } }}

--- a/src/stories/components/Forms/Forms.stories.mdx
+++ b/src/stories/components/Forms/Forms.stories.mdx
@@ -24,7 +24,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## TextInput
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="TextInput"
     parameters={{
@@ -41,7 +41,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Textarea
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Textarea"
     parameters={{
@@ -58,7 +58,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Checkbox
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Checkbox"
     parameters={{
@@ -75,7 +75,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## CheckboxCustom
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="CheckboxCustom"
     parameters={{
@@ -92,7 +92,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## CheckboxStates
 
-<Canvas withSource="close">
+<Canvas sourceState="hidden">
   <Story name="CheckboxStates" decorators={[Grid(5)]} parameters={getDecoratedParameters(CheckboxStates)}>
     {() => CheckboxStates}
   </Story>
@@ -100,7 +100,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Radio
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Radio"
     parameters={{
@@ -117,7 +117,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## RadioCustom
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="RadioCustom"
     parameters={{
@@ -134,7 +134,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## RadioStates
 
-<Canvas withSource="close">
+<Canvas sourceState="hidden">
   <Story name="RadioStates" decorators={[Grid(5)]} parameters={getDecoratedParameters(RadioStates)}>
     {() => RadioStates}
   </Story>
@@ -142,7 +142,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Select
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Select"
     parameters={{
@@ -159,7 +159,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## DatePicker
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="DatePicker"
     parameters={{
@@ -176,7 +176,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Validation
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Validation"
     parameters={{
@@ -193,7 +193,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Hint
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Hint"
     parameters={{
@@ -210,7 +210,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## HintInfo
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="HintInfo"
     parameters={{

--- a/src/stories/components/GlobalAlert/GlobalAlert.stories.mdx
+++ b/src/stories/components/GlobalAlert/GlobalAlert.stories.mdx
@@ -8,6 +8,6 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default">{() => Default}</Story>
 </Canvas>

--- a/src/stories/components/Header/Header.stories.mdx
+++ b/src/stories/components/Header/Header.stories.mdx
@@ -12,18 +12,18 @@ import Search from "./templates/Search.html";
 
 ## Default
 
-<Canvas withSource="close">
+<Canvas sourceState="hidden">
   <Story name="Default">{() => Default}</Story>
 </Canvas>
 
 ## Mobile
 
-<Canvas withSource="none" {...getCanvasMobileProps()}>
+<Canvas sourceState="none" {...getCanvasMobileProps()}>
   <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>
 
 ## Search
 
-<Canvas withSource="close">
+<Canvas sourceState="hidden">
   <Story name="Search">{() => Search}</Story>
 </Canvas>

--- a/src/stories/components/Images/Images.stories.mdx
+++ b/src/stories/components/Images/Images.stories.mdx
@@ -18,7 +18,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>
@@ -26,7 +26,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Figure
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Figure" parameters={getDecoratedParameters(Figure)}>
     {() => Figure}
   </Story>
@@ -34,7 +34,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## WithCaptionCredits
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithCaptionCredits" parameters={getDecoratedParameters(WithCaptionCredits)}>
     {() => WithCaptionCredits}
   </Story>
@@ -42,7 +42,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## PullLeftRight
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="PullLeftRight" parameters={getDecoratedParameters(PullLeftRight)}>
     {() => PullLeftRight}
   </Story>
@@ -50,7 +50,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## WithLargerImage
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithLargerImage" parameters={getDecoratedParameters(WithLargerImage)}>
     {() => WithLargerImage}
   </Story>
@@ -58,7 +58,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## WithoutBorder
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithoutBorder" parameters={getDecoratedParameters(WithoutBorder)}>
     {() => WithoutBorder}
   </Story>

--- a/src/stories/components/ImagesGallery/ImagesGallery.stories.mdx
+++ b/src/stories/components/ImagesGallery/ImagesGallery.stories.mdx
@@ -11,7 +11,7 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/Index/Index.stories.mdx
+++ b/src/stories/components/Index/Index.stories.mdx
@@ -18,7 +18,7 @@ Not included in Forgov SWE documentation.
 
 ## Basic
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Basic" parameters={getDecoratedParameters(Basic)}>
     {() => Basic}
   </Story>

--- a/src/stories/components/InpageNavigation/InpageNavigation.stories.mdx
+++ b/src/stories/components/InpageNavigation/InpageNavigation.stories.mdx
@@ -13,7 +13,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/LastUpdate/LastUpdate.stories.mdx
+++ b/src/stories/components/LastUpdate/LastUpdate.stories.mdx
@@ -11,7 +11,7 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/LoadingSpinner/LoadingSpinner.stories.mdx
+++ b/src/stories/components/LoadingSpinner/LoadingSpinner.stories.mdx
@@ -13,7 +13,7 @@ import AbsoluteCenter from "./templates/AbsoluteCenter.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" decorators={[Grid(2)]} parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>
@@ -21,7 +21,7 @@ import AbsoluteCenter from "./templates/AbsoluteCenter.html";
 
 ## CenterAligned
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="CenterAligned"
     decorators={[Grid(2)]}
@@ -33,7 +33,7 @@ import AbsoluteCenter from "./templates/AbsoluteCenter.html";
 
 ## AbsoluteCenter
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="AbsoluteCenter" parameters={getDecoratedParameters(AbsoluteCenter)}>
     {() => AbsoluteCenter}
   </Story>

--- a/src/stories/components/LocationAddressSearch/LocationAddressSearch.stories.mdx
+++ b/src/stories/components/LocationAddressSearch/LocationAddressSearch.stories.mdx
@@ -11,7 +11,7 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/PageAlert/PageAlert.stories.mdx
+++ b/src/stories/components/PageAlert/PageAlert.stories.mdx
@@ -13,7 +13,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/Pagination/Pagination.stories.mdx
+++ b/src/stories/components/Pagination/Pagination.stories.mdx
@@ -11,7 +11,7 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/Print/Print.stories.mdx
+++ b/src/stories/components/Print/Print.stories.mdx
@@ -14,7 +14,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>
@@ -22,7 +22,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## PrintGuide
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="PrintGuide" parameters={getDecoratedParameters(PrintGuide)}>
     {() => PrintGuide}
   </Story>

--- a/src/stories/components/PromotionalBanner/PromotionalBanner.stories.mdx
+++ b/src/stories/components/PromotionalBanner/PromotionalBanner.stories.mdx
@@ -12,7 +12,7 @@ import WithImage from "./templates/WithImage.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>
@@ -20,7 +20,7 @@ import WithImage from "./templates/WithImage.html";
 
 ## WithImage
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="WithImage" parameters={getDecoratedParameters(WithImage)}>
     {() => WithImage}
   </Story>

--- a/src/stories/components/QuickExit/QuickExit.stories.mdx
+++ b/src/stories/components/QuickExit/QuickExit.stories.mdx
@@ -11,7 +11,7 @@ import Default from "./templates/Default.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/SearchCategories/SearchCategories.stories.mdx
+++ b/src/stories/components/SearchCategories/SearchCategories.stories.mdx
@@ -18,7 +18,7 @@ Not included in Forgov SWE documentation.
 
 ## Basic
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Basic" parameters={getDecoratedParameters(Basic)}>
     {() => Basic}
   </Story>

--- a/src/stories/components/SectionNavigation/SectionNavigation.stories.mdx
+++ b/src/stories/components/SectionNavigation/SectionNavigation.stories.mdx
@@ -13,7 +13,7 @@ Requires `#QgContent` ancestor.
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>

--- a/src/stories/components/SocialMedia/SocialMedia.stories.mdx
+++ b/src/stories/components/SocialMedia/SocialMedia.stories.mdx
@@ -13,7 +13,7 @@ import TwitterFeed from "./templates/TwitterFeed.html";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>
@@ -21,7 +21,7 @@ import TwitterFeed from "./templates/TwitterFeed.html";
 
 ## FacebookFeed
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="FacebookFeed"
     parameters={{ ...getDecoratedParameters(Default), chromatic: { disableSnapshot: true } }}
@@ -32,7 +32,7 @@ import TwitterFeed from "./templates/TwitterFeed.html";
 
 ## TwitterFeed
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="TwitterFeed"
     parameters={{ ...getDecoratedParameters(Default), chromatic: { disableSnapshot: true } }}

--- a/src/stories/components/Table/Table.stories.mdx
+++ b/src/stories/components/Table/Table.stories.mdx
@@ -14,7 +14,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default" parameters={getDecoratedParameters(Default)}>
     {() => Default}
   </Story>
@@ -22,7 +22,7 @@ Requires `#QgPrimaryContent` ancestor.
 
 ## NoStripe
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="NoStripe" parameters={getDecoratedParameters(NoStripe)}>
     {() => NoStripe}
   </Story>

--- a/src/stories/components/Video/Video.stories.mdx
+++ b/src/stories/components/Video/Video.stories.mdx
@@ -14,7 +14,7 @@ import Vimeo from "./templates/Vimeo.html";
 
 {/* disabled snapshot for this story as youtube player animation cause story renewal in every generation. */}
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Youtube"
     parameters={{
@@ -28,7 +28,7 @@ import Vimeo from "./templates/Vimeo.html";
 
 ## Vimeo
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Vimeo" parameters={getDecoratedParameters(Vimeo)}>
     {() => Vimeo}
   </Story>

--- a/src/stories/foundations/Iconography/Iconography.stories.mdx
+++ b/src/stories/foundations/Iconography/Iconography.stories.mdx
@@ -10,6 +10,6 @@ import { QgContent } from "../../decorators";
 
 ## Default
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Default">{() => Default}</Story>
 </Canvas>

--- a/src/stories/foundations/Typography/Typography.stories.mdx
+++ b/src/stories/foundations/Typography/Typography.stories.mdx
@@ -14,19 +14,19 @@ import { QgContent } from "../../decorators";
 
 ## Headings
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Headings">{() => Headings}</Story>
 </Canvas>
 
 ## Paragraphs
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Paragraphs">{() => Paragraphs}</Story>
 </Canvas>
 
 ## Links
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story
     name="Links"
     decorators={[QgContent]}
@@ -44,12 +44,12 @@ import { QgContent } from "../../decorators";
 
 ## Lists
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Lists">{() => Lists}</Story>
 </Canvas>
 
 ## Code
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Code">{() => Code}</Story>
 </Canvas>

--- a/src/stories/franchises/Dfv/Dfv.stories.mdx
+++ b/src/stories/franchises/Dfv/Dfv.stories.mdx
@@ -21,7 +21,7 @@ Not included in Forgov SWE documentation.
 
 ## DfvCards
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="DfvCards" parameters={getDecoratedParameters(DfvCards)}>
     {() => DfvCards}
   </Story>
@@ -29,7 +29,7 @@ Not included in Forgov SWE documentation.
 
 ## AsideButton
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="AsideButton" parameters={getDecoratedParameters(AsideButton)}>
     {() => AsideButton}
   </Story>
@@ -37,7 +37,7 @@ Not included in Forgov SWE documentation.
 
 ## DfvBack
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="DfvBack" parameters={getDecoratedParameters(DfvBack)}>
     {() => DfvBack}
   </Story>
@@ -45,7 +45,7 @@ Not included in Forgov SWE documentation.
 
 ## LinksList
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="LinksList" parameters={getDecoratedParameters(LinksList)}>
     {() => LinksList}
   </Story>

--- a/src/stories/franchises/digital-dashboard/Dashboard.stories.mdx
+++ b/src/stories/franchises/digital-dashboard/Dashboard.stories.mdx
@@ -36,7 +36,7 @@ Not included in Forgov SWE documentation.
 
 ## Tenders
 
-<Canvas withSource="open">
+<Canvas sourceState="shown">
   <Story name="Tenders" parameters={getDecoratedParameters(Tenders)}>
     {() => Tenders}
   </Story>

--- a/src/stories/helpers/getMobileProps.js
+++ b/src/stories/helpers/getMobileProps.js
@@ -9,7 +9,9 @@ export const getStoryMobileParameters = () => ({
   },
   docs: {
     // Opt-out of inline rendering
-    inlineStories: false,
+    story: {
+      inline: false,
+    },
   },
   chromatic: {
     viewports: [


### PR DESCRIPTION
This PR is to resolve some warnings (regarding deprecated codes) and errors related to storybook
- Replacing withSource with sourceState
- Replacing inlineStories with story.inline
- Importing from @storybook/blocks instead of @storybook/addon-docs/blocks
- DOM_VK_END is not defined