### PR TITLE
QOLDEV-533 Removing unnecessary space in accordion

### DIFF
--- a/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
+++ b/src/assets/_project/_blocks/components/accordion/_qg-accordion.scss
@@ -27,6 +27,9 @@
       .acc-heading {
 
         padding: 1rem;
+        a.qg-accordion--ga {
+          margin: 0 !important;
+        }
 
         &:hover > a, 
         &:focus > a,

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -9,7 +9,7 @@
   // make exception for certain classes, which need to re-visit for better optimization
   &:not(.qg-feature-box .qg-link):not(.qg-index a.qg-index-item):not(.page-item
       .page-link):not(.dfv-cards--type-top-prompt
-      a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.QSAR-records-search a) {
+      a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.QSAR-records-search a):not(.acc-heading a) {
 
     text-underline-offset: $text-underline-offset;
     // not sure why Asif need to add this, which will have side-effect on customised style added by franchise.

--- a/src/assets/_project/_blocks/components/link/_qg-link.scss
+++ b/src/assets/_project/_blocks/components/link/_qg-link.scss
@@ -9,7 +9,7 @@
   // make exception for certain classes, which need to re-visit for better optimization
   &:not(.qg-feature-box .qg-link):not(.qg-index a.qg-index-item):not(.page-item
       .page-link):not(.dfv-cards--type-top-prompt
-      a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.QSAR-records-search a):not(.acc-heading a) {
+      a.card):not(.search-categories__index-toggle):not(.search-categories__index):not(.QSAR-records-search a) {
 
     text-underline-offset: $text-underline-offset;
     // not sure why Asif need to add this, which will have side-effect on customised style added by franchise.


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/contact-us/complaints-process

Removing in unnecessary space in accordion multi-line header for screens ~485px and below.

**Before:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/e156caf1-b509-4775-b119-d90217868553)

**After:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/e1501fa4-47cf-427e-9c6c-ff2ddb498705)
