### PR TITLE
QOLDEV-592 Excluding NoStripe tables from border: 0

### DIFF
--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -24,7 +24,7 @@
     font-weight: bold;
   }
   table {
-    &:not(.table-bordered) {
+    &:not(.table-bordered):not(.qg-table-no-stripes) {
       td {
         border: 0; // defaulting to borderless
       }


### PR DESCRIPTION
NoStripe tables should be excluded from this css rule as well. Because they are bordered.

https://uat.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/table/_nocache