### PR TITLE
QOLDEV-577 Removing source code toggle button for mobile stories

### DIFF
--- a/src/stories/components/Accordion/Accordion.stories.mdx
+++ b/src/stories/components/Accordion/Accordion.stories.mdx
@@ -56,8 +56,8 @@ import States from "./templates/States.html";
 
 ## Mobile
 
-<Canvas sourceState="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>
+<Canvas withSource="none" {...getCanvasMobileProps()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters(Mobile)} height={getStoryMobileHeight()}>
     {() => Mobile}
   </Story>
 </Canvas>

--- a/src/stories/components/Accordion/Accordion.stories.mdx
+++ b/src/stories/components/Accordion/Accordion.stories.mdx
@@ -57,7 +57,7 @@ import States from "./templates/States.html";
 ## Mobile
 
 <Canvas withSource="none" {...getCanvasMobileProps()}>
-  <Story name="Mobile" parameters={getStoryMobileParameters(Mobile)} height={getStoryMobileHeight()}>
+  <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>
     {() => Mobile}
   </Story>
 </Canvas>

--- a/src/stories/components/Footer/Footer.stories.mdx
+++ b/src/stories/components/Footer/Footer.stories.mdx
@@ -27,7 +27,7 @@ import Mobile from "./templates/Footer.html";
 
 {/* Footer always contributed difference in Chromatic snapshot, hence disabled snapshot temporary, need further investigation (caused by the feedback button) */}
 
-<Canvas sourceState="none" {...getCanvasMobileProps()}>
+<Canvas withSource="none" {...getCanvasMobileProps()}>
   <Story
     name="Mobile"
     parameters={{ ...getStoryMobileParameters(), chromatic: { disableSnapshot: true } }}

--- a/src/stories/components/Header/Header.stories.mdx
+++ b/src/stories/components/Header/Header.stories.mdx
@@ -18,12 +18,12 @@ import Search from "./templates/Search.html";
 
 ## Mobile
 
-<Canvas sourceState="none" {...getCanvasMobileProps()}>
+<Canvas withSource="none" {...getCanvasMobileProps()}>
   <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>
 
 ## Search
 
 <Canvas sourceState="hidden">
-  <Story name="Search">{() => Search}</Story>
+  <Story name="Search" height="350px">{() => Search}</Story>
 </Canvas>

--- a/src/stories/templates/AggregationPage/ApplicationPage.stories.mdx
+++ b/src/stories/templates/AggregationPage/ApplicationPage.stories.mdx
@@ -17,6 +17,6 @@ import Mobile from "../../../template-pages/application-page.html";
 
 ## Mobile
 
-<Canvas sourceState="none" {...getCanvasMobileProps()}>
+<Canvas withSource="none" {...getCanvasMobileProps()}>
   <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/ContentPage/ContentPage.stories.mdx
+++ b/src/stories/templates/ContentPage/ContentPage.stories.mdx
@@ -17,6 +17,6 @@ import Mobile from "../../../template-pages/content-page.html";
 
 ## Mobile
 
-<Canvas sourceState="none" {...getCanvasMobileProps()}>
+<Canvas withSource="none" {...getCanvasMobileProps()}>
   <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/ContentPageNoAsides/ContentPageNoAsides.stories.mdx
+++ b/src/stories/templates/ContentPageNoAsides/ContentPageNoAsides.stories.mdx
@@ -17,6 +17,6 @@ import Mobile from "../../../template-pages/content-page-no-asides.html";
 
 ## Mobile
 
-<Canvas sourceState="none" {...getCanvasMobileProps()}>
+<Canvas withSource="none" {...getCanvasMobileProps()}>
   <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/ContentPageWithoutLocation/ContentPageWithoutLocation.stories.mdx
+++ b/src/stories/templates/ContentPageWithoutLocation/ContentPageWithoutLocation.stories.mdx
@@ -17,6 +17,6 @@ import Mobile from "../../../template-pages/content-page-without-location.html";
 
 ## Mobile
 
-<Canvas sourceState="none" {...getCanvasMobileProps()}>
+<Canvas withSource="none" {...getCanvasMobileProps()}>
   <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/IndexPage/IndexPage.stories.mdx
+++ b/src/stories/templates/IndexPage/IndexPage.stories.mdx
@@ -17,6 +17,6 @@ import Mobile from "../../../template-pages/index-page.html";
 
 ## Mobile
 
-<Canvas sourceState="none" {...getCanvasMobileProps()}>
+<Canvas withSource="none" {...getCanvasMobileProps()}>
   <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>

--- a/src/stories/templates/TopicIndexPage/TopicIndexPage.stories.mdx
+++ b/src/stories/templates/TopicIndexPage/TopicIndexPage.stories.mdx
@@ -17,6 +17,6 @@ import Mobile from "../../../template-pages/topic-index-page.html";
 
 ## Mobile
 
-<Canvas sourceState="none" {...getCanvasMobileProps()}>
+<Canvas withSource="none" {...getCanvasMobileProps()}>
   <Story name="Mobile" parameters={getStoryMobileParameters()} height={getStoryMobileHeight()}>{() => Mobile}</Story>
 </Canvas>


### PR DESCRIPTION
Source code toggle buttons for mobile stories are not working. It is set to sourceState=”none”. It was supposed to not display the source code.

Example:
https://qld-gov-au.github.io/qg-web-template/?path=/docs/components-accordion--docs
https://qld-gov-au.github.io/qg-web-template/?path=/docs/components-header--docs

Also applying height to search story.