### PR TITLE
Qoldev 618 service finder button

### DIFF
--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -66,9 +66,9 @@
     .qg-service-finder__container .qg-search-concierge-content {
       a:not(.btn):not(.qg-btn) {
         @include qg-link-styles__theme-black-always(black, $qg-global-primary-darker-grey);
-      }
-      > a:not(.btn):not(.qg-btn) {
-        padding: 20px 35px 0 35px;
+        > & {
+          padding: 20px 35px 0 35px;
+        }
       }
     }
     &.light{

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -66,9 +66,9 @@
     .qg-service-finder__container .qg-search-concierge {
       a:not(.btn):not(.qg-btn) {
         @include qg-link-styles__theme-black-always(black, $qg-global-primary-darker-grey);
-        > & {
-          padding: 20px 35px 0 35px;
-        }
+      }
+      > a:not(.btn):not(.qg-btn) {
+        padding: 20px 35px 0 35px;
       }
     }
     &.light{

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -63,7 +63,7 @@
         }
       }
     }
-    .qg-service-finder__container .qg-search-concierge-content {
+    .qg-service-finder__container .qg-search-concierge {
       a:not(.btn):not(.qg-btn) {
         @include qg-link-styles__theme-black-always(black, $qg-global-primary-darker-grey);
         > & {

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -63,11 +63,11 @@
         }
       }
     }
-    .qg-service-finder__container .qg-search-concierge {
+    .qg-service-finder__container .qg-search-concierge-content {
       a:not(.btn):not(.qg-btn) {
         @include qg-link-styles__theme-black-always(black, $qg-global-primary-darker-grey);
       }
-      > a:not(.btn):not(.qg-btn) {
+      & > a:not(.btn):not(.qg-btn) {
         padding: 20px 35px 0 35px;
       }
     }

--- a/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
+++ b/src/assets/_project/_blocks/layout/banners/_qg-banner-blurb.scss
@@ -64,7 +64,7 @@
       }
     }
     .qg-service-finder__container .qg-search-concierge-content {
-      a {
+      a:not(.btn):not(.qg-btn) {
         @include qg-link-styles__theme-black-always(black, $qg-global-primary-darker-grey);
       }
       > a:not(.btn):not(.qg-btn) {


### PR DESCRIPTION
https://oss-uat.clients.squiz.net/services
Fixing the default state for the button within service finder dropdown when you search for a term like 'registration'.
Also fixing the padding for the immediate link 'Browse all categories'

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/1815ef5b-6696-43de-a156-ca5f34faa422)

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/12235790-f961-4370-b4c6-198ccd61e98b)
