### PR TITLE
QOLDEV-620 Making table-sm bootstrap class working in SWE

### DIFF
--- a/src/assets/_project/_blocks/components/tables/_tables.scss
+++ b/src/assets/_project/_blocks/components/tables/_tables.scss
@@ -23,33 +23,34 @@
     color: #000;
     font-weight: bold;
   }
-  table {
-    &:not(.table-bordered):not(.qg-table-no-stripes) {
-      td {
-        border: 0; // defaulting to borderless
-      }
+}
+
+table {
+  &:not(.table-bordered):not(.qg-table-no-stripes) {
+    td {
+      border: 0; // defaulting to borderless
     }
-    @extend .table; // inheriting bootstrap table styles
-    thead {
-      tr {
-        background-color: #005375;
-        color: white;
-      }
-    }
+  }
+  @extend .table; // inheriting bootstrap table styles
+  thead {
     tr {
-      background: #f6f6f6;
-      &:nth-child(even) {
-        background: white;
-      }
-      td {
-        padding: 1em;
-      }
+      background-color: #005375;
+      color: white;
     }
-    &.qg-table-no-stripes {
-      @extend .table-bordered;
-      tr {
-        background: white;
-      }
+  }
+  tr {
+    background: #f6f6f6;
+    &:nth-child(even) {
+      background: white;
+    }
+    td {
+      padding: 1em;
+    }
+  }
+  &.qg-table-no-stripes {
+    @extend .table-bordered;
+    tr {
+      background: white;
     }
   }
 }


### PR DESCRIPTION
Bootstrap class `table-sm` was not working when applied in WYSIWYG editors. Taking `table { ..} `out of `#qg-primary-content` made the classes work as expected.

Adding table-sm class to existing tables on:
https://oss-uat.clients.squiz.net/dev/ghazal/test-table/_nocache
https://uat.forgov.qld.gov.au/information-and-communication-technology/communication-and-publishing/website-and-digital-publishing/website-standards-guidelines-and-templates/swe/components/table

![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/9673c7b9-4180-47d4-9fbb-42b2b0ae64bc)

