### PR TITLE
QOLDEV-679 new CSS rule to support the Form IO Multifile upload component

### DIFF
--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -295,16 +295,9 @@
     }
 
     .choices__item {
+      padding: 4px 10px;
       line-height: inherit;
       font-size: 1rem;
-    }
-
-    .choices__list--dropdown .choices__item {
-      padding: 10px;
-    }
-
-    .choices__input {
-        padding: 10px !important;
     }
 
     .choices__item.choices__item--selectable:not(.choices__item--choice) {
@@ -444,10 +437,14 @@
 
   //error container
   .formio-error-wrapper {
-    color: white !important;
+    color: #FFF !important;
     background-color: white !important;
     border-color: white !important;
     padding: 0;
+
+    &.formio-component-file {
+      color: #721C24 !important;
+    }
   }
 
   //error labels


### PR DESCRIPTION
Adds a new CSS hotfix to support Multifile Upload component when in error state.
 
<img width="702" alt="Screenshot 2023-11-22 at 11 16 47 am" src="https://github.com/qld-gov-au/qg-web-template/assets/126438309/f1ea7b4b-12b8-4b20-aca4-835c77c142e5">

