### PR TITLE
Qoldev 668 changing breakpoint for topic index pages

### DIFF
--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -125,6 +125,10 @@
 // Legacy stuff
 #qg-one-col, #qg-three-col, #qg-two-col-aside:not(.wide), #qg-two-col-nav:not(.wide) {
   .qg-index-links > .qg-index-item {
+    @include media-breakpoint-up(xs) {
+      @include make-col(6);
+      max-width: 49%;
+    }
     @include media-breakpoint-up(sm) {
       @include make-col(12); // Make the page one-col. Example: Topic Index page with an aside
     }

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -128,11 +128,11 @@
     @include media-breakpoint-up(md) {
       @include make-col(12);
     }
-    @include breakpoint(sm) {
+    @include media-breakpoint-only(sm) {
       @include make-col(6);
       max-width: 49%;
     }
-    @include breakpoint(xs) {
+    @include media-breakpoint-only(xs) {
       @include make-col(12); // Make the page one-col. Example: Topic Index page with an aside
     }
   }

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -71,11 +71,10 @@
       list-style: none;
     }
   }
-  @include breakpoint(xs) {
+  @include breakpoint(sm) {
     margin-right: 0;
     margin-left: 0;
-    &> .qg-index-item{
-      //width: 100%;
+    & > .qg-index-item {
       margin-bottom: 1.5rem !important;
       padding-left: 0 !important;
       padding-right: 0 !important;

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -128,7 +128,7 @@
     @include media-breakpoint-up(sm) {
       @include make-col(6);
     }
-    @include media-breakpoint(xs) {
+    @include breakpoint(xs) {
       @include make-col(12); // Make the page one-col. Example: Topic Index page with an aside
     }
   }

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -125,8 +125,12 @@
 // Legacy stuff
 #qg-one-col, #qg-three-col, #qg-two-col-aside:not(.wide), #qg-two-col-nav:not(.wide) {
   .qg-index-links > .qg-index-item {
-    @include media-breakpoint-up(sm) {
+    @include media-breakpoint-up(md) {
+      @include make-col(12);
+    }
+    @include breakpoint(sm) {
       @include make-col(6);
+      max-width: 49%;
     }
     @include breakpoint(xs) {
       @include make-col(12); // Make the page one-col. Example: Topic Index page with an aside

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -71,7 +71,7 @@
       list-style: none;
     }
   }
-  @include breakpoint(sm) {
+  @include media-breakpoint-down(sm) {
     margin-right: 0;
     margin-left: 0;
     & > .qg-index-item {

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -1,6 +1,7 @@
 #qg-primary-content .qg-index-links {
   @extend .d-flex;
   @extend .flex-wrap;
+  justify-content: space-between;
   padding-top: 1em;
   .qg-index-item.content-only{
     h2, p, ul, &> div &> span {
@@ -145,6 +146,7 @@
   .qg-index-links > .qg-index-item {
     @include media-breakpoint-up(sm) {
       @include make-col(6); // Make the page two-col. Example: Topic index page with no aside
+      max-width: 49%;
     }
     &:nth-child(3) {
       @include qg-index-item;

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -125,11 +125,10 @@
 // Legacy stuff
 #qg-one-col, #qg-three-col, #qg-two-col-aside:not(.wide), #qg-two-col-nav:not(.wide) {
   .qg-index-links > .qg-index-item {
-    @include media-breakpoint(xs) {
-      @include make-col(6);
-      max-width: 49%;
-    }
     @include media-breakpoint-up(sm) {
+      @include make-col(6);
+    }
+    @include media-breakpoint(xs) {
       @include make-col(12); // Make the page one-col. Example: Topic Index page with an aside
     }
   }

--- a/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
+++ b/src/assets/_project/_blocks/layout/_pagemodels/_index.scss
@@ -125,7 +125,7 @@
 // Legacy stuff
 #qg-one-col, #qg-three-col, #qg-two-col-aside:not(.wide), #qg-two-col-nav:not(.wide) {
   .qg-index-links > .qg-index-item {
-    @include media-breakpoint-up(xs) {
+    @include media-breakpoint(xs) {
       @include make-col(6);
       max-width: 49%;
     }


### PR DESCRIPTION
Updating the breakpoint on topic and franchise pages
Also made the card-look index items to wrap into two column in md size screens

**Franchise landing page:** https://oss-uat.clients.squiz.net/transport/transport/_nocache
**Topic index page:** https://oss-uat.clients.squiz.net/transport/registration/_nocache

**768-991 px:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/8bea1aa2-348d-487a-9474-1bc8b8adb950)

**< 768px:**
![image](https://github.com/qld-gov-au/qg-web-template/assets/126438691/baa9fff4-a5cd-433a-b873-fef401999ec7)
