### PR TITLE
QOLDEV-694 HOTFIX: update FormIO CSS in SWE to fix formIO error state

### DIFF
--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -450,7 +450,8 @@
     border-color: white !important;
     padding: 0;
 
-    &.formio-component-file {
+    &.formio-component-file,
+    &.formio-component-select {
       color: #721C24 !important;
     }
   }


### PR DESCRIPTION
Hotfix for a visual bug in SWE, where white text displays on white background in FormIO dropdown. Occurs when dropdown has a formio-error-wrapper class.

This fix is a permanent replacement in SWE for a temporary hotfix applied directly to Squiz under CHG-444.

Tested on UAT under web-template-release branch v4.4.0-test