### PR TITLE
QOLDEV-666 Styling dropdowns

### DIFF
--- a/src/assets/_project/_blocks/components/forms/_qg-forms.scss
+++ b/src/assets/_project/_blocks/components/forms/_qg-forms.scss
@@ -204,7 +204,6 @@
   .form-control.dropdown {
     padding: 8px;
     border-radius: $borderRadius;
-    height: 44px;
 
     &:focus-within {
       color: #495057;
@@ -213,6 +212,10 @@
       outline: 0;
       box-shadow: 0 0 0 $borderWidth $focusBoxShadow;
     }
+  }
+
+  .form-control.dropdown {
+    height: 44px;
   }
 
   .form-control,

--- a/src/docs/assets/css/ictdashboard.css
+++ b/src/docs/assets/css/ictdashboard.css
@@ -769,8 +769,8 @@ body .qg-projects-search form .questions input.inp {
 #results-table a {
   font-size: 0.9em; }
 
-#ictdb.dataTable.small,
-#ictdb.dataTable.medium {
+#ictdb.small,
+#ictdb.medium {
   width: 100%; }
 
 .qg-projects-search.medium {
@@ -793,18 +793,18 @@ body .qg-projects-search form .questions input.inp {
 #content-container .article .box-sizing .border {
   margin-left: 2.9em; }
 
-#ictdb.dataTable.small .desktop-view,
-#ictdb.dataTable .mobile-view {
+#ictdb.small .desktop-view,
+#ictdb .mobile-view {
   display: none; }
 
-#ictdb.dataTable.small .mobile-view {
+#ictdb.small .mobile-view {
   display: list-item; }
 
-#ictdb.dataTable .projectStatusCol img {
+#ictdb .projectStatusCol img {
   width: 20px;
   margin: auto 0.5em -0.4em 0; }
 
-#ictdb.dataTable .projectStatusCol span {
+#ictdb .projectStatusCol span {
   position: absolute;
   left: -9999em; }
 
@@ -1015,7 +1015,7 @@ div.actions ul {
   #content-container .article .box-sizing .border {
     left-padding: 0 !important;
     margin-left: 0 !important; }
-  #ictdb.dataTable {
+  #ictdb {
     width: 100%; }
   #overview-expenditure .graph li span,
   #overview-status .graph li span {
@@ -1027,7 +1027,7 @@ div.actions ul {
     color: #000000 !important; }
   table#example td.details-control {
     padding-left: 0; }
-  #ictdb.dataTable .projectStatusCol span {
+  #ictdb .projectStatusCol span {
     position: relative;
     left: 0;
     top: -0.2em;

--- a/src/stories/franchises/digital-dashboard/templates/Projects.html
+++ b/src/stories/franchises/digital-dashboard/templates/Projects.html
@@ -2,7 +2,7 @@
 
 <div id="qg-two-col-aside" class="row wide">
   <div id="qg-primary-content" role="main">
-    <div id="ictdb" class="projectstable dataTable">
+    <div id="ictdb" class="projectstable">
       <div class="toggle-sort">
         <a href="javascript:void(0)" id="toggleInformation">Show all</a>
       </div>


### PR DESCRIPTION
Applying the fix height only to form.io drop downs without impacting other elements.
Also removed 'datatable' class from digital dashborad project table as it caused errors on the page. It is not a searchable table on the live site: https://www.qld.gov.au/digitalprojectsdashboard/projects